### PR TITLE
refactor: RequestBuilder 내부 리팩토링

### DIFF
--- a/backend/src/test/java/com/jujeol/AcceptanceTest.java
+++ b/backend/src/test/java/com/jujeol/AcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.jujeol;
 
+import com.jujeol.RequestBuilder.Function;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +27,15 @@ public class AcceptanceTest {
         request = new RequestBuilder(restDocumentation);
     }
 
-    protected RequestBuilder request() {
-        return request;
+    /**
+     * use-example :
+     *  request()
+     *      .get("/path")                   http method
+     *      .withoutLog()                   default : true
+     *      .withDocument("identifier")     default : withoutDocument
+     *      .build();
+     */
+    protected Function request() {
+        return request.builder();
     }
 }


### PR DESCRIPTION
## resolve #issue 17

### 설명
- Given-When-Then 클래스 구조를 Function-Option으로 변경
- AcceptanceTest 에 사용 예제 작성

### 기타
- Function은 http request 작성 위주 (예 : GET /api body)
- Option은 추가적인 옵션 위주 (예 : 문서화, 로그)