### PR TITLE
refactor: 해당 주류에 선호도가 없을 때 예외 대신 0 반환

### DIFF
--- a/backend/src/main/java/com/jujeol/commons/exception/ExceptionCodeAndDetails.java
+++ b/backend/src/main/java/com/jujeol/commons/exception/ExceptionCodeAndDetails.java
@@ -9,7 +9,6 @@ import com.jujeol.drink.exception.NotFoundReviewException;
 import com.jujeol.member.exception.InvalidTokenException;
 import com.jujeol.member.exception.KakaoAccessException;
 import com.jujeol.member.exception.NoSuchMemberException;
-import com.jujeol.member.exception.NoSuchPreferenceException;
 import com.jujeol.member.exception.UnauthorizedUserException;
 import java.util.Arrays;
 import lombok.AllArgsConstructor;
@@ -26,7 +25,6 @@ public enum ExceptionCodeAndDetails {
     INVALID_TOKEN("1003", "access token이 유효하지 않습니다.", InvalidTokenException.class),
     NO_SUCH_MEMBER("1004", "해당 id의 유저가 없습니다.", NoSuchMemberException.class),
     UNAUTHORIZED_USER("1005", "권한이 없는 유저입니다.", UnauthorizedUserException.class),
-    NO_SUCH_PREFERENCE("1006", "해당 주류에 대한 선호도가 없습니다", NoSuchPreferenceException.class),
 
     INVALID_ALCOHOL_BY_VOLUME("2001", "해당 주류의 도수가 잘 못 되었습니다.",
             InvalidAlcoholByVolumeException.class),

--- a/backend/src/main/java/com/jujeol/drink/application/DrinkService.java
+++ b/backend/src/main/java/com/jujeol/drink/application/DrinkService.java
@@ -5,9 +5,9 @@ import com.jujeol.drink.domain.Drink;
 import com.jujeol.drink.domain.DrinkRepository;
 import com.jujeol.drink.domain.ReviewRepository;
 import com.jujeol.drink.exception.NotFoundDrinkException;
+import com.jujeol.member.domain.Member;
 import com.jujeol.member.domain.Preference;
 import com.jujeol.member.domain.PreferenceRepository;
-import com.jujeol.member.exception.NoSuchPreferenceException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ public class DrinkService {
     public List<DrinkDto> showDrinks() {
         return drinkRepository.findAll(Pageable.ofSize(7))
                 .get()
-                .map(drink -> DrinkDto.from(drink, Preference.of(drink, 0), fileServerUrl))
+                .map(drink -> DrinkDto.from(drink, Preference.from(drink, 0), fileServerUrl))
                 .collect(Collectors.toList());
     }
 
@@ -39,7 +39,7 @@ public class DrinkService {
         Drink drink = drinkRepository.findById(id)
                 .orElseThrow(NotFoundDrinkException::new);
 
-        Preference preference = Preference.of(drink, 0.0);
+        Preference preference = Preference.from(drink, 0.0);
 
         return DrinkDto.from(drink, preference, fileServerUrl);
     }
@@ -50,7 +50,7 @@ public class DrinkService {
 
         Preference preference = preferenceRepository
                 .findByMemberIdAndDrinkId(memberId, drinkId)
-                .orElseThrow(NoSuchPreferenceException::new);
+                .orElseGet(() -> Preference.from(Member.from(memberId), drink, 0.0));
 
         return DrinkDto.from(drink, preference, fileServerUrl);
     }

--- a/backend/src/main/java/com/jujeol/drink/ui/DrinkController.java
+++ b/backend/src/main/java/com/jujeol/drink/ui/DrinkController.java
@@ -48,12 +48,13 @@ public class DrinkController {
             @PathVariable Long id,
             @AuthenticationPrincipal LoginMember loginMember
     ) {
-        if (loginMember.getAuthority().isAnonymous()) {
-            DrinkDto drinkDto = drinkService.showDrinkDetail(id);
-            DrinkDetailResponse drinkDetailResponse = DrinkDetailResponse.from(drinkDto);
-            return ResponseEntity.ok(CommonResponse.from(drinkDetailResponse));
+        DrinkDto drinkDto = new DrinkDto();
+        if (loginMember.isAnonymous()) {
+            drinkDto = drinkService.showDrinkDetail(id);
         }
-        DrinkDto drinkDto = drinkService.showDrinkDetail(id, loginMember.getId());
+        if (loginMember.isMember()) {
+            drinkDto = drinkService.showDrinkDetail(id, loginMember.getId());
+        }
         DrinkDetailResponse drinkDetailResponse = DrinkDetailResponse.from(drinkDto);
         return ResponseEntity.ok(CommonResponse.from(drinkDetailResponse));
     }

--- a/backend/src/main/java/com/jujeol/member/application/MemberService.java
+++ b/backend/src/main/java/com/jujeol/member/application/MemberService.java
@@ -42,10 +42,10 @@ public class MemberService {
 
         preferenceRepository
                 .findByMemberIdAndDrinkId(member.getId(), drink.getId())
-                .ifPresentOrElse(exist -> exist.updateRate(preferenceRequest.getRate()),
+                .ifPresentOrElse(exist -> exist.updateRate(preferenceRequest.getPreferenceRate()),
                         () -> {
                             Preference newPreference = Preference
-                                    .of(member, drink, preferenceRequest.getRate());
+                                    .from(member, drink, preferenceRequest.getPreferenceRate());
                             preferenceRepository.save(newPreference);
                         }
                 );

--- a/backend/src/main/java/com/jujeol/member/application/dto/PreferenceRequest.java
+++ b/backend/src/main/java/com/jujeol/member/application/dto/PreferenceRequest.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PreferenceRequest {
 
-    private double rate;
+    private double preferenceRate;
 }

--- a/backend/src/main/java/com/jujeol/member/domain/Preference.java
+++ b/backend/src/main/java/com/jujeol/member/domain/Preference.java
@@ -38,11 +38,11 @@ public class Preference {
         this.rate = rate;
     }
 
-    public static Preference of(Drink drink, double rate) {
+    public static Preference from(Drink drink, double rate) {
         return new Preference(null, drink, rate);
     }
 
-    public static Preference of(Member member, Drink drink, double rate) {
+    public static Preference from(Member member, Drink drink, double rate) {
         return new Preference(member, drink, rate);
     }
 

--- a/backend/src/main/java/com/jujeol/member/exception/NoSuchPreferenceException.java
+++ b/backend/src/main/java/com/jujeol/member/exception/NoSuchPreferenceException.java
@@ -1,7 +1,0 @@
-package com.jujeol.member.exception;
-
-import com.jujeol.commons.exception.JujeolException;
-
-public class NoSuchPreferenceException extends JujeolException {
-
-}

--- a/backend/src/test/java/com/jujeol/TestDataLoader.java
+++ b/backend/src/test/java/com/jujeol/TestDataLoader.java
@@ -79,7 +79,7 @@ public class TestDataLoader implements CommandLineRunner {
         MEMBER = memberRepository.save(member1);
         MEMBER2 = memberRepository.save(member2);
 
-        PREFERENCE = preferenceRepository.save(Preference.of(MEMBER, stella, 3.5));
+        PREFERENCE = preferenceRepository.save(Preference.from(MEMBER, stella, 3.5));
 
         Review review1 = Review.from("천재 윤피카", stella, MEMBER);
         Review review2 = Review.from("천재 크로플", stella, MEMBER);

--- a/backend/src/test/java/com/jujeol/drink/acceptance/DrinkAcceptanceTest.java
+++ b/backend/src/test/java/com/jujeol/drink/acceptance/DrinkAcceptanceTest.java
@@ -34,7 +34,7 @@ public class DrinkAcceptanceTest extends AcceptanceTest {
         //then
         List<DrinkSimpleResponse> expectedResult = BEERS.stream()
                 .filter(drink -> drink.getId() < 8)
-                .map(drink -> DrinkDto.from(drink, Preference.of(drink, 0), ""))
+                .map(drink -> DrinkDto.from(drink, Preference.from(drink, 0), ""))
                 .map(DrinkSimpleResponse::from)
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## resolve #79 

### 설명
- rate로 요청 보내는 대신 preferenceRate로 변경
- 사용하지 않는 NoSuchPreferenceException 삭제

