### PR TITLE
fix: 리뷰 생성 및 수정시 리뷰 내용 제한 예외 추가

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -207,6 +207,29 @@ include::{snippets}/reviews/create-fail-limit/http-request.adoc[]
 
 include::{snippets}/reviews/create-fail-limit/http-response.adoc[]
 
+=== 리뷰 생성(실패_3)
+==== 리뷰 내용이 비어있을 경우
+
+- Request
+
+include::{snippets}/reviews/create-fail-emptyContent/http-request.adoc[]
+
+- Response
+
+include::{snippets}/reviews/create-fail-emptyContent/http-response.adoc[]
+
+
+=== 리뷰 생성(실패_4)
+==== 리뷰 내용이 300자 이상일 경우
+
+- Request
+
+include::{snippets}/reviews/create-fail-contentOver300/http-request.adoc[]
+
+- Response
+
+include::{snippets}/reviews/create-fail-contentOver300/http-response.adoc[]
+
 === 리뷰 조회
 ==== 상세 화면에서 특정 상품에 대한 리뷰를 조회
 
@@ -274,6 +297,27 @@ include::{snippets}/reviews/update-fail-author/http-request.adoc[]
 
 include::{snippets}/reviews/update-fail-author/http-response.adoc[]
 
+=== 리뷰 수정(실패_5)
+==== 리뷰 수정할 때 빈 내용으로 수정할 경우
+
+- Request
+
+include::{snippets}/reviews/update-fail-emptyContent/http-request.adoc[]
+
+- Response
+
+include::{snippets}/reviews/update-fail-emptyContent/http-response.adoc[]
+
+=== 리뷰 수정(실패_6)
+==== 리뷰를 수정할 때 리뷰 내용이 300자 이상일 경우
+
+- Request
+
+include::{snippets}/reviews/update-fail-contentOver300/http-request.adoc[]
+
+- Response
+
+include::{snippets}/reviews/update-fail-contentOver300/http-response.adoc[]
 
 === 리뷰 식제
 ==== 선택한 리뷰를 삭제

--- a/backend/src/main/java/com/jujeol/commons/exception/ExceptionCodeAndDetails.java
+++ b/backend/src/main/java/com/jujeol/commons/exception/ExceptionCodeAndDetails.java
@@ -4,6 +4,7 @@ import com.jujeol.drink.exception.CreateReviewLimitException;
 import com.jujeol.drink.exception.InvalidAlcoholByVolumeException;
 import com.jujeol.drink.exception.InvalidDrinkNameException;
 import com.jujeol.drink.exception.InvalidEnglishNameException;
+import com.jujeol.drink.exception.InvalidReviewContentException;
 import com.jujeol.drink.exception.NotExistReviewInDrinkException;
 import com.jujeol.drink.exception.NotFoundDrinkException;
 import com.jujeol.drink.exception.NotFoundReviewException;
@@ -36,7 +37,9 @@ public enum ExceptionCodeAndDetails {
     NOT_FOUND_REVIEW("2005", "해당하는 id의 리뷰를 찾을 수 없습니다.", NotFoundReviewException.class),
     NOT_EXIST_REVIEW_IN_DRINK("2006", "해당 주류에 존재하지 않는 리뷰입니다.",
             NotExistReviewInDrinkException.class),
-    CREATE_REVIEW_LIMIT("2007", "동일 상품에 대한 리뷰는 하루에 하나만 작성할 수 있습니다.", CreateReviewLimitException.class);
+    CREATE_REVIEW_LIMIT("2007", "동일 상품에 대한 리뷰는 하루에 하나만 작성할 수 있습니다.", CreateReviewLimitException.class),
+    INVALID_CONTENT_LENGTH("2008", "리뷰는 빈 공백이거나 300자를 넘을 수 없습니다.", InvalidReviewContentException.class)
+    ;
 
     private String code;
     private String message;

--- a/backend/src/main/java/com/jujeol/drink/domain/Review.java
+++ b/backend/src/main/java/com/jujeol/drink/domain/Review.java
@@ -3,6 +3,7 @@ package com.jujeol.drink.domain;
 import com.jujeol.member.domain.Member;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -26,7 +27,8 @@ public class Review {
     private Long id;
 
     @Column(nullable = false)
-    private String content;
+    @Embedded
+    private ReviewContent content;
 
     @ManyToOne
     @JoinColumn(name = "drink_id")
@@ -42,7 +44,7 @@ public class Review {
     private LocalDateTime modifiedAt;
 
     public static Review from(String content, Drink drink, Member member) {
-        return new Review(null, content, drink, member, null, null);
+        return new Review(null, new ReviewContent(content), drink, member, null, null);
     }
 
     public void toDrink(Drink drink) {
@@ -50,7 +52,7 @@ public class Review {
     }
 
     public void editContent(String content) {
-        this.content = content;
+        this.content = new ReviewContent(content);
     }
 
     public boolean isReviewOf(Drink drink) {
@@ -70,6 +72,10 @@ public class Review {
     @PreUpdate
     public void preUpdate() {
         modifiedAt = LocalDateTime.now();
+    }
+
+    public String getContent() {
+        return content.getContent();
     }
 
     public Long getMemberId() {

--- a/backend/src/main/java/com/jujeol/drink/domain/ReviewContent.java
+++ b/backend/src/main/java/com/jujeol/drink/domain/ReviewContent.java
@@ -1,0 +1,28 @@
+package com.jujeol.drink.domain;
+
+import com.jujeol.drink.exception.InvalidReviewContentException;
+import java.util.Objects;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReviewContent {
+
+    private String content;
+
+    public ReviewContent(String content) {
+
+        if(!validateReviewContent(content)) {
+            throw new InvalidReviewContentException();
+        }
+        this.content = content;
+    }
+
+    private boolean validateReviewContent(String content) {
+        return !Objects.isNull(content) && !content.isBlank() && content.length() <= 300;
+    }
+}

--- a/backend/src/main/java/com/jujeol/drink/exception/InvalidReviewContentException.java
+++ b/backend/src/main/java/com/jujeol/drink/exception/InvalidReviewContentException.java
@@ -1,0 +1,7 @@
+package com.jujeol.drink.exception;
+
+import com.jujeol.commons.exception.JujeolException;
+
+public class InvalidReviewContentException extends JujeolException {
+
+}

--- a/backend/src/test/java/com/jujeol/drink/acceptance/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/jujeol/drink/acceptance/ReviewAcceptanceTest.java
@@ -84,6 +84,47 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
                 .isEqualTo(ExceptionCodeAndDetails.CREATE_REVIEW_LIMIT.getMessage());
     }
 
+    @DisplayName("리뷰 생성 - 실패(리뷰 내용이 비어 있을 경우)")
+    @Test
+    void createReviewTest_fail_reviewEmptyContent() {
+        //given
+        String content = "";
+        ReviewRequest reviewRequest = new ReviewRequest(content);
+        ExtractableResponse<Response> response = request()
+                .post("/drinks/2/reviews", reviewRequest)
+                .withUser()
+                .withDocument("reviews/create-fail-emptyContent")
+                .build().totalResponse();
+
+        JujeolExceptionDto body = response.body().as(JujeolExceptionDto.class);
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(body.getCode()).isEqualTo(ExceptionCodeAndDetails.INVALID_CONTENT_LENGTH.getCode());
+        assertThat(body.getMessage())
+                .isEqualTo(ExceptionCodeAndDetails.INVALID_CONTENT_LENGTH.getMessage());
+    }
+
+    @DisplayName("리뷰 생성 - 실패(리뷰 내용이 300자가 넘을 경우)")
+    @Test
+    void createReviewTest_fail_reviewContentOver300() {
+        //given
+        String content = "이 내용은 300자가 넘는 내용입니다. 300자 까지 뭐라고 쓸지 모르겠네요.. 자소서 쓰는 기분... 저희팀 소개를 하자면 일단 저 웨지 나봄 크로플 피카 소롱 서니 티케 이렇게 7명으로 이루어져있구요! 모두 한명 한명 맡은바 임무를 잘 수행하고 있습니다. 저는 여기 팀에 들어오게 되어서 얼마나 좋은지 몰라요 다들 너무 잘 챙겨주시고 잘 이끌어주셔서 감사합니다. 그리구 코로나 또한 빨리 종식되었으면 좋겠어요 다들 못보니까 너무 아쉽고 힘드네요 ㅠㅠ 팀프로젝트가 성공리에 마무리되어 끝났으면 좋겠고 서로 싸우지말고 잘 진행햇으면 좋겠습니다. 다들 건강 챙기시구 코로나 조심하세요 그럼 이만 줄이겠습니다.";
+
+        ReviewRequest reviewRequest = new ReviewRequest(content);
+        ExtractableResponse<Response> response = request()
+                .post("/drinks/2/reviews", reviewRequest)
+                .withUser()
+                .withDocument("reviews/create-fail-contentOver300")
+                .build().totalResponse();
+
+        JujeolExceptionDto body = response.body().as(JujeolExceptionDto.class);
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(body.getCode()).isEqualTo(ExceptionCodeAndDetails.INVALID_CONTENT_LENGTH.getCode());
+        assertThat(body.getMessage())
+                .isEqualTo(ExceptionCodeAndDetails.INVALID_CONTENT_LENGTH.getMessage());
+    }
+
     @DisplayName("리뷰 조회 - 성공")
     @Test
     void showReviews() {
@@ -232,6 +273,54 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
                 .isEqualTo(ExceptionCodeAndDetails.UNAUTHORIZED_USER.getCode());
         assertThat(body.getMessage())
                 .isEqualTo(ExceptionCodeAndDetails.UNAUTHORIZED_USER.getMessage());
+    }
+
+    @DisplayName("리뷰 수정 - 실패(리뷰 내용이 비어 있을 경우)")
+    @Test
+    public void updateReviewTest_fail_reviewEmptyContent() {
+        //given
+        String content = "";
+        ReviewRequest reviewRequest = new ReviewRequest(content);
+
+        //when
+        ExtractableResponse<Response> response = request()
+                .put("/drinks/3/reviews/13", reviewRequest)
+                .withUser()
+                .withDocument("reviews/update-fail-emptyContent")
+                .build().totalResponse();
+
+        JujeolExceptionDto body = response.body().as(JujeolExceptionDto.class);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(body.getCode())
+                .isEqualTo(ExceptionCodeAndDetails.INVALID_CONTENT_LENGTH.getCode());
+        assertThat(body.getMessage())
+                .isEqualTo(ExceptionCodeAndDetails.INVALID_CONTENT_LENGTH.getMessage());
+    }
+
+    @DisplayName("리뷰 수정 - 실패(리뷰 내용이 300자가 넘을 경우)")
+    @Test
+    public void updateReviewTest_fail_reviewContentOver300() {
+        //given
+        String content = "이 내용은 300자가 넘는 내용입니다. 300자 까지 뭐라고 쓸지 모르겠네요.. 자소서 쓰는 기분... 저희팀 소개를 하자면 일단 저 웨지 나봄 크로플 피카 소롱 서니 티케 이렇게 7명으로 이루어져있구요! 모두 한명 한명 맡은바 임무를 잘 수행하고 있습니다. 저는 여기 팀에 들어오게 되어서 얼마나 좋은지 몰라요 다들 너무 잘 챙겨주시고 잘 이끌어주셔서 감사합니다. 그리구 코로나 또한 빨리 종식되었으면 좋겠어요 다들 못보니까 너무 아쉽고 힘드네요 ㅠㅠ 팀프로젝트가 성공리에 마무리되어 끝났으면 좋겠고 서로 싸우지말고 잘 진행햇으면 좋겠습니다. 다들 건강 챙기시구 코로나 조심하세요 그럼 이만 줄이겠습니다.";
+        ReviewRequest reviewRequest = new ReviewRequest(content);
+
+        //when
+        ExtractableResponse<Response> response = request()
+                .put("/drinks/3/reviews/13", reviewRequest)
+                .withUser()
+                .withDocument("reviews/update-fail-contentOver300")
+                .build().totalResponse();
+
+        JujeolExceptionDto body = response.body().as(JujeolExceptionDto.class);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(body.getCode())
+                .isEqualTo(ExceptionCodeAndDetails.INVALID_CONTENT_LENGTH.getCode());
+        assertThat(body.getMessage())
+                .isEqualTo(ExceptionCodeAndDetails.INVALID_CONTENT_LENGTH.getMessage());
     }
 
     @DisplayName("리뷰 삭제 - 성공")

--- a/backend/src/test/java/com/jujeol/drink/domain/ReviewContentTest.java
+++ b/backend/src/test/java/com/jujeol/drink/domain/ReviewContentTest.java
@@ -1,20 +1,33 @@
 package com.jujeol.drink.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jujeol.drink.exception.InvalidReviewContentException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class ReviewContentTest {
 
+    @DisplayName("리뷰 생성 - 성공")
+    @ParameterizedTest
+    @ValueSource(strings = {"와 진짜 맛있다!!", "너무 행복해요!", "이 내용은 정확히 300자입니다. 300자 까지 뭐라고 쓸지 모르겠네요.. 자소서 쓰는 기분... 저희팀 소개를 하자면 일단 저 웨지 나봄 크로플 피카 소롱 서니 티케 이렇게 7명으로 이루어져있구요! 모두 한명 한명 맡은바 임무를 잘 수행하고 있습니다. 저는 여기 팀에 들어오게 되어서 얼마나 좋은지 몰라요 다들 너무 잘 챙겨주시고 잘 이끌어주셔서 감사합니다. 그리구 코로나 또한 빨리 종식되었으면 좋겠어요 다들 못보니까 너무 아쉽고 힘드네요 ㅠㅠ 다들 건강 챙기시구 코로나 조심하세요 그럼 이만 줄이겠습니다. 다들사랑해용8자만더쓰자얍히"})
+    void reviewContentTest(String content) {
+        //given
+        ReviewContent reviewContent = new ReviewContent(content);
+        //when
+        //then
+        assertThat(reviewContent.getContent()).isEqualTo(content);
+    }
+
     @DisplayName("리뷰 생성 - 실패(리뷰 내용이 공백이거나 300자가 넘을 경우)")
     @ParameterizedTest
     @NullSource
-    @ValueSource(strings = {"", "   ", "이 내용은 300자가 넘는 내용입니다. 300자 까지 뭐라고 쓸지 모르겠네요.. 자소서 쓰는 기분... 저희팀 소개를 하자면 일단 저 웨지 나봄 크로플 피카 소롱 서니 티케 이렇게 7명으로 이루어져있구요! 모두 한명 한명 맡은바 임무를 잘 수행하고 있습니다. 저는 여기 팀에 들어오게 되어서 얼마나 좋은지 몰라요 다들 너무 잘 챙겨주시고 잘 이끌어주셔서 감사합니다. 그리구 코로나 또한 빨리 종식되었으면 좋겠어요 다들 못보니까 너무 아쉽고 힘드네요 ㅠㅠ 팀프로젝트가 성공리에 마무리되어 끝났으면 좋겠고 서로 싸우지말고 잘 진행햇으면 좋겠습니다. 다들 건강 챙기시구 코로나 조심하세요 그럼 이만 줄이겠습니다."})
-    void reviewContentTest(String content) {
+    @ValueSource(strings = {"", "   ", "이 내용은 301자입니다. 300자 까지 뭐라고 쓸지 모르겠네요.. 자소서 쓰는 기분... 저희팀 소개를 하자면 일단 저 웨지 나봄 크로플 피카 소롱 서니 티케 이렇게 7명으로 이루어져있구요! 모두 한명 한명 맡은바 임무를 잘 수행하고 있습니다. 저는 여기 팀에 들어오게 되어서 얼마나 좋은지 몰라요 다들 너무 잘 챙겨주시고 잘 이끌어주셔서 감사합니다. 그리구 코로나 또한 빨리 종식되었으면 좋겠어요 다들 못보니까 너무 아쉽고 힘드네요 ㅠㅠ 다들 건강 챙기시구 코로나 조심하세요 그럼 이만 줄이겠습니다.  나머지 내용은 301자를채우기위한"})
+    void reviewContentTest_fail(String content) {
         //given
         //when
         //then

--- a/backend/src/test/java/com/jujeol/drink/domain/ReviewContentTest.java
+++ b/backend/src/test/java/com/jujeol/drink/domain/ReviewContentTest.java
@@ -1,0 +1,24 @@
+package com.jujeol.drink.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jujeol.drink.exception.InvalidReviewContentException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ReviewContentTest {
+
+    @DisplayName("리뷰 생성 - 실패(리뷰 내용이 공백이거나 300자가 넘을 경우)")
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "   ", "이 내용은 300자가 넘는 내용입니다. 300자 까지 뭐라고 쓸지 모르겠네요.. 자소서 쓰는 기분... 저희팀 소개를 하자면 일단 저 웨지 나봄 크로플 피카 소롱 서니 티케 이렇게 7명으로 이루어져있구요! 모두 한명 한명 맡은바 임무를 잘 수행하고 있습니다. 저는 여기 팀에 들어오게 되어서 얼마나 좋은지 몰라요 다들 너무 잘 챙겨주시고 잘 이끌어주셔서 감사합니다. 그리구 코로나 또한 빨리 종식되었으면 좋겠어요 다들 못보니까 너무 아쉽고 힘드네요 ㅠㅠ 팀프로젝트가 성공리에 마무리되어 끝났으면 좋겠고 서로 싸우지말고 잘 진행햇으면 좋겠습니다. 다들 건강 챙기시구 코로나 조심하세요 그럼 이만 줄이겠습니다."})
+    void reviewContentTest(String content) {
+        //given
+        //when
+        //then
+        assertThatThrownBy(() -> new ReviewContent(content))
+                .isInstanceOf(InvalidReviewContentException.class);
+    }
+}


### PR DESCRIPTION
## resolve #95 #96 

### 설명
- 리뷰가 비어있거나 300자 이상일 경우 예외
- 리뷰 생성 및 수정 테스트 추가
- API 문서 추가

### 기타
