### PR TITLE
feat: 랜덤 닉네임 및 자기소개에 대한 dummyAPI 구현

### DIFF
--- a/backend/src/main/java/com/jujeol/member/application/dto/MemberResponse.java
+++ b/backend/src/main/java/com/jujeol/member/application/dto/MemberResponse.java
@@ -12,8 +12,10 @@ import lombok.NoArgsConstructor;
 public class MemberResponse {
 
     private Long id;
+    private String nickname;
+    private String bio;
 
     public static MemberResponse from(Member member) {
-        return new MemberResponse(member.getId());
+        return new MemberResponse(member.getId(), "청바지_123", "청춘은 바로 지금!");
     }
 }


### PR DESCRIPTION
## Related #122 

### 설명
- GET members/me api Reponse에 name, bio정보 추가
```javascript
HTTP/1.1 200 OK

{
  "data" : {
    "id" : 1,
    "nickname" : "청바지_123" // 하드코딩 
    "bio" : "청춘은 바로 지금!!" // 하드코딩
}
```
### 기타
