### PR TITLE
fix: 내가 마신 술의 선호도 실제값으로 수정

### DIFF
--- a/backend/src/main/java/com/jujeol/member/application/MemberService.java
+++ b/backend/src/main/java/com/jujeol/member/application/MemberService.java
@@ -86,10 +86,10 @@ public class MemberService {
     }
 
     public Page<DrinkDto> findDrinks(Long memberId, Pageable pageable) {
-        return preferenceRepository.findDrinksOfMineWithPreference(memberId, pageable)
-                .map(drink -> DrinkDto.create(
-                        drink,
-                        Preference.from(drink, 3.5),
+        return preferenceRepository.findByMemberIdOrderByCreatedAtDesc(memberId, pageable)
+                .map(preference -> DrinkDto.create(
+                        preference.getDrink(),
+                        preference,
                         fileServerUrl
                         )
                 );

--- a/backend/src/main/java/com/jujeol/member/domain/PreferenceRepository.java
+++ b/backend/src/main/java/com/jujeol/member/domain/PreferenceRepository.java
@@ -1,6 +1,5 @@
 package com.jujeol.member.domain;
 
-import com.jujeol.drink.domain.Drink;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,14 +17,5 @@ public interface PreferenceRepository extends JpaRepository<Preference, Long> {
     @Query("SELECT AVG(p.rate) FROM Preference p WHERE p.drink.id = :drinkId")
     Optional<Double> averageOfPreferenceRate(Long drinkId);
 
-    @Query(value = ""
-            + "select p.drink from Preference p "
-            + "inner join Drink d on d.id = p.drink.id "
-            + "where p.member.id = :memberId "
-            + "order by p.createdAt desc",
-            countQuery = ""
-                    + "select count(p.drink) from Preference p "
-                    + "inner join Drink d on d.id = p.drink.id "
-                    + "where p.member.id = :memberId ")
-    Page<Drink> findDrinksOfMineWithPreference(Long memberId, Pageable pageable);
+    Page<Preference> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 }

--- a/backend/src/test/java/com/jujeol/member/acceptance/MemberInfoAcceptanceTest.java
+++ b/backend/src/test/java/com/jujeol/member/acceptance/MemberInfoAcceptanceTest.java
@@ -1,7 +1,10 @@
 package com.jujeol.member.acceptance;
 
-import static com.jujeol.drink.DrinkTestContainer.*;
-import static com.jujeol.member.fixture.TestMember.*;
+import static com.jujeol.drink.DrinkTestContainer.APPLE;
+import static com.jujeol.drink.DrinkTestContainer.OB;
+import static com.jujeol.drink.DrinkTestContainer.STELLA;
+import static com.jujeol.drink.DrinkTestContainer.TIGER_LEMON;
+import static com.jujeol.member.fixture.TestMember.CROFFLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jujeol.AcceptanceTest;
@@ -37,8 +40,8 @@ public class MemberInfoAcceptanceTest extends AcceptanceTest {
         final Long tigerLemonId = 주류_등록(TIGER_LEMON);
 
         memberAcceptanceTool.선호도_등록(obId, 2.4, CROFFLE);
-        memberAcceptanceTool.선호도_등록(stellaId, 2.4, CROFFLE);
-        memberAcceptanceTool.선호도_등록(tigerLemonId, 2.4, CROFFLE);
+        memberAcceptanceTool.선호도_등록(stellaId, 3.0, CROFFLE);
+        memberAcceptanceTool.선호도_등록(tigerLemonId, 4.5, CROFFLE);
 
         //when
         List<MemberDrinkResponse> responses = request().get("/members/me/drinks")
@@ -49,7 +52,9 @@ public class MemberInfoAcceptanceTest extends AcceptanceTest {
 
         //then
         assertThat(responses).hasSize(3);
-        assertThat(responses).extracting("id").containsExactlyInAnyOrder(obId, stellaId, tigerLemonId);
+        assertThat(responses).extracting("id")
+                .containsExactlyInAnyOrder(obId, stellaId, tigerLemonId);
+        assertThat(responses).extracting("preferenceRate").containsExactlyInAnyOrder(2.4, 3.0, 4.5);
     }
 
     @DisplayName("내가 남긴 리뷰 모아보기 - 성공")
@@ -73,7 +78,7 @@ public class MemberInfoAcceptanceTest extends AcceptanceTest {
                 .build();
 
         //then
-        페이징_검증(response.pageInfo(), 1,1,3,3);
+        페이징_검증(response.pageInfo(), 1, 1, 3, 3);
 
         final List<MemberReviewResponse> memberReviewResponses = response
                 .convertBodyToList(MemberReviewResponse.class);

--- a/backend/src/test/java/com/jujeol/member/domain/MemberInfoRepositoryTest.java
+++ b/backend/src/test/java/com/jujeol/member/domain/MemberInfoRepositoryTest.java
@@ -9,6 +9,7 @@ import com.jujeol.drink.domain.repository.CategoryRepository;
 import com.jujeol.drink.domain.repository.DrinkRepository;
 import com.jujeol.drink.domain.repository.ReviewRepository;
 import com.jujeol.member.domain.nickname.Nickname;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -111,18 +112,17 @@ public class MemberInfoRepositoryTest {
                 .collect(Collectors.toList());
 
         //when
-        Page<Drink> drinkResponses = preferenceRepository
-                .findDrinksOfMineWithPreference(savedMember.getId(), Pageable.ofSize(10));
+        Page<Preference> responses = preferenceRepository
+                .findByMemberIdOrderByCreatedAtDesc(savedMember.getId(), Pageable.ofSize(10));
 
         //then
-        List<Long> drinkIds = drinks.stream()
-                .map(Drink::getId)
-                .sorted(Comparator.reverseOrder())
-                .collect(Collectors.toList());
-        List<Long> actualIds = drinkResponses.stream().map(Drink::getId)
+        Collections.reverse(drinks);
+
+        List<Drink> actualDrinks = responses.stream()
+                .map(Preference::getDrink)
                 .collect(Collectors.toList());
 
-        assertThat(drinkResponses).hasSize(drinks.size());
-        assertThat(actualIds).isEqualTo(drinkIds);
+        assertThat(responses).hasSize(drinks.size());
+        assertThat(actualDrinks).isEqualTo(drinks);
     }
 }


### PR DESCRIPTION
## resolve #182 

### 설명
- 내가 마신 술의 선호도 값이 3.5(더미 데이터)만 오던 오류 수정
- 선호도 기준으로 상품을 찾아오던 부분을 Preference 가져오기 -> Drink 추출 방식으로 변경
- 테스트에서 선호도 값을 검증하도록 추가
- Reponse 는 아래와 같습니다
```json
HTTP/1.1 200 OK
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Content-Type: application/json
Transfer-Encoding: chunked
Date: Sat, 31 Jul 2021 08:29:32 GMT
Keep-Alive: timeout=60
Connection: keep-alive
Content-Length: 557

{
  "data" : [ {
    "id" : 3,
    "name" : "타이거 라들러 레몬",
    "imageUrl" : "/KakaoTalk_Image_2021-07-08-19-58-22_008.png",
    "preferenceRate" : 4.5
  }, {
    "id" : 2,
    "name" : "스텔라",
    "imageUrl" : "/KakaoTalk_Image_2021-07-08-19-58-09_001.png",
    "preferenceRate" : 3.0
  }, {
    "id" : 1,
    "name" : "오비",
    "imageUrl" : "/KakaoTalk_Image_2021-07-08-19-58-22_007.png",
    "preferenceRate" : 2.4
  } ],
  "pageInfo" : {
    "currentPage" : 1,
    "lastPage" : 1,
    "countPerPage" : 7,
    "totalSize" : 3
  }
```

### 기타
