### PR TITLE
fix: 전체 카테고리 디비 등록 구현 (dev, local)

### DIFF
--- a/backend/src/main/java/com/jujeol/DataLoader.java
+++ b/backend/src/main/java/com/jujeol/DataLoader.java
@@ -43,6 +43,9 @@ public class DataLoader implements CommandLineRunner {
         Category SOJU = categoryRepository.save(Category.create("소주", "SOJU"));
         Category WINE = categoryRepository.save(Category.create("와인", "WINE"));
         Category MAKGEOLLI = categoryRepository.save(Category.create("막걸리", "MAKGEOLLI"));
+        Category YANGJU = categoryRepository.save(Category.create("양주", "YANGJU"));
+        Category COCKTAIL = categoryRepository.save(Category.create("칵테일", "COCKTAIL"));
+        Category ETC = categoryRepository.save(Category.create("기타", "ETC"));
 
         // Drink Data
         Drink stella = Drink.create("스텔라", "stella", 5.5, "w_400/stella_artois_w400.png", 0.0, BEER);


### PR DESCRIPTION
## resolve #203

### 설명
- 데브, 로컬 환경에서 디비에 기본 카테고리 입력 추가

### 기타
종류 | 키
-- | --
맥주 | BEER
소주 | SOJU
와인 | WINE
막걸리 | MAKGEOLLI
양주 | YANGJU
칵테일 | COCKTAIL
기타 | ETC

