### PR TITLE
fix: isExists 메서드를 queryDSL 구문으로 변경

### DIFF
--- a/backend/src/main/java/com/jujeol/member/domain/MemberCustomRepository.java
+++ b/backend/src/main/java/com/jujeol/member/domain/MemberCustomRepository.java
@@ -1,0 +1,6 @@
+package com.jujeol.member.domain;
+
+public interface MemberCustomRepository {
+
+    boolean isExists(String nickname);
+}

--- a/backend/src/main/java/com/jujeol/member/domain/MemberRepository.java
+++ b/backend/src/main/java/com/jujeol/member/domain/MemberRepository.java
@@ -6,14 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
 
     @Query("select m from Member m where m.provider.provideId = :provideId")
     Optional<Member> findByProvideId(String provideId);
 
     @Query("select m from Member m where m.nickname.nickname like :nickname% order by m.createdAt desc")
     List<Member> findOneStartingWithNicknameAndMostRecent(String nickname, Pageable pageable);
-
-    @Query(value = "select exists (select m.id from member m where m.nickname = ?)", nativeQuery = true)
-    boolean isExists(String nickname);
 }

--- a/backend/src/main/java/com/jujeol/member/domain/MemberRepositoryImpl.java
+++ b/backend/src/main/java/com/jujeol/member/domain/MemberRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.jujeol.member.domain;
+
+import static com.jujeol.member.domain.QMember.member;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean isExists(String nickname) {
+        long memberCount = queryFactory.selectFrom(member)
+                .where(member.nickname.isNotNull())
+                .fetchCount();
+        return memberCount > 0;
+    }
+}


### PR DESCRIPTION
## resolve #209

### 설명
- Mysql에 적용 안되는 메소드를 queryDSL로 변경

