### PR TITLE
refactor: DB에 이미지 파일 경로 뿐만 아니라 실제 url을 저장하도록 로직 수정

### DIFF
--- a/backend/src/main/java/com/jujeol/DataLoader.java
+++ b/backend/src/main/java/com/jujeol/DataLoader.java
@@ -38,83 +38,83 @@ public class DataLoader implements CommandLineRunner {
 
         // Drink Data
         // 첫 데이터
-        Drink stella = Drink.create("스텔라 아르투아", "STELLA ARTOIS ", 5.0, "w_400/stella_artois_w400.png", 0.0, BEER);
-        Drink kgb = Drink.create("KGB 레몬", "KGB Lemon", 5.0, "w_400/kgb_w400.png", 0.0, BEER);
-        Drink efes = Drink.create("에페스", "EFES",5.0, "w_400/efes_w400.png", 0.0, BEER);
-        Drink tiger_rad = Drink.create("타이거 라들러 자몽", "Tiger Rad", 2.0, "w_400/tiger_raddler_grapefruit_w400.png", 0.0, BEER);
-        Drink tsingtao = Drink.create("칭따오 스타우트", "TSINGTAO STOUT", 4.8, "w_400/tsingtao_w400.png", 0.0, BEER);
-        Drink gom_pyo = Drink.create("세븐브로이 곰표 밀맥주", "7brau Gompyo wheatbear", 4.5, "w_400/gom_pyo_w400.png", 0.0, BEER);
-        Drink ob = Drink.create("오비 라거", "OB Lager", 4.6, "w_400/ob_lager_w400.png", 0.0, BEER);
-        Drink tigerLemon = Drink.create("타이거 라들러 레몬", "Tiger Lemon", 2.0, "w_400/tiger_raddler_lemon_w400.png", 0.0, BEER);
+        Drink stella = Drink.create("스텔라 아르투아", "STELLA ARTOIS ", 5.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/stella_artois_w400.png", 0.0, BEER);
+        Drink kgb = Drink.create("KGB 레몬", "KGB Lemon", 5.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/kgb_w400.png", 0.0, BEER);
+        Drink efes = Drink.create("에페스", "EFES",5.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/efes_w400.png", 0.0, BEER);
+        Drink tiger_rad = Drink.create("타이거 라들러 자몽", "Tiger Rad", 2.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/tiger_raddler_grapefruit_w400.png", 0.0, BEER);
+        Drink tsingtao = Drink.create("칭따오 스타우트", "TSINGTAO STOUT", 4.8, "https://dmaxaug2ve9od.cloudfront.net/w_400/tsingtao_w400.png", 0.0, BEER);
+        Drink gom_pyo = Drink.create("세븐브로이 곰표 밀맥주", "7brau Gompyo wheatbear", 4.5, "https://dmaxaug2ve9od.cloudfront.net/w_400/gom_pyo_w400.png", 0.0, BEER);
+        Drink ob = Drink.create("오비 라거", "OB Lager", 4.6, "https://dmaxaug2ve9od.cloudfront.net/w_400/ob_lager_w400.png", 0.0, BEER);
+        Drink tigerLemon = Drink.create("타이거 라들러 레몬", "Tiger Lemon", 2.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/tiger_raddler_lemon_w400.png", 0.0, BEER);
 
         // 스프리드 시트 데이터 추가
         final List<Drink> drinks_spread = Arrays.asList(
                 // 맥주
-                Drink.create("쥬시후레쉬맥주", "Juicy Fresh Beer", 4.5, "w_400/Juicy_Fresh_Beer_w400.png", 0.0, BEER),
-                Drink.create("금성맥주", "Gold Star Beer", 5.1, "w_400/Gold_Star_Beer_w400.png", 0.0, BEER),
-                Drink.create("제주 거멍 에일", "Jeju Geomeong Ale", 4.3, "w_400/Jeju_Geomeong_Ale_w400.png", 0.0, BEER),
-                Drink.create("에페스 필스너", "EFES Pilsner", 5.0, "w_400/EFES_Pilsner_w400.png", 0.0, BEER),
-                Drink.create("오드 괴즈 틸퀸 아렌시아", "Oude Gueze Tilquin a L'Ancienne", 7.0, "w_400/Oude_Gueze_Tilquin_a_L'Ancienne_w400.png", 0.0, BEER),
+                Drink.create("쥬시후레쉬맥주", "Juicy Fresh Beer", 4.5, "https://dmaxaug2ve9od.cloudfront.net/w_400/Juicy_Fresh_Beer_w400.png", 0.0, BEER),
+                Drink.create("금성맥주", "Gold Star Beer", 5.1, "https://dmaxaug2ve9od.cloudfront.net/w_400/Gold_Star_Beer_w400.png", 0.0, BEER),
+                Drink.create("제주 거멍 에일", "Jeju Geomeong Ale", 4.3, "https://dmaxaug2ve9od.cloudfront.net/w_400/Jeju_Geomeong_Ale_w400.png", 0.0, BEER),
+                Drink.create("에페스 필스너", "EFES Pilsner", 5.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/EFES_Pilsner_w400.png", 0.0, BEER),
+                Drink.create("오드 괴즈 틸퀸 아렌시아", "Oude Gueze Tilquin a L'Ancienne", 7.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Oude_Gueze_Tilquin_a_L'Ancienne_w400.png", 0.0, BEER),
 
                 // 소주
-                Drink.create("시원한청풍소주", "C1Soju", 17.2, "w_400/c1soju_w400.png", 0.0, SOJU),
-                Drink.create("참이슬", "Chamisul Soju", 16.9, "w_400/charm_i_sel_soju_w400.png", 0.0, SOJU),
-                Drink.create("처음처럼", "cheo-um-cheo-rum Soju", 16.5, "w_400/cheo_um_cheo_rum_soju_w400.png", 0.0, SOJU),
-                Drink.create("자몽에이슬", "jamong-eh-i-sul-soju", 13.0, "w_400/jamong_eh_i_sul_soju_w400.png", 0.0, SOJU),
-                Drink.create("참이슬 오리지날", "charm-i-sel-soju", 20.1, "w_400/charm_i_sel_original_soju_w400.png", 0.0, SOJU),
-                Drink.create("진로", "jinro-soju", 16.5, "w_400/jinro_soju_w400.png", 0.0, SOJU),
+                Drink.create("시원한청풍소주", "C1Soju", 17.2, "https://dmaxaug2ve9od.cloudfront.net/w_400/c1soju_w400.png", 0.0, SOJU),
+                Drink.create("참이슬", "Chamisul Soju", 16.9, "https://dmaxaug2ve9od.cloudfront.net/w_400/charm_i_sel_soju_w400.png", 0.0, SOJU),
+                Drink.create("처음처럼", "cheo-um-cheo-rum Soju", 16.5, "https://dmaxaug2ve9od.cloudfront.net/w_400/cheo_um_cheo_rum_soju_w400.png", 0.0, SOJU),
+                Drink.create("자몽에이슬", "jamong-eh-i-sul-soju", 13.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/jamong_eh_i_sul_soju_w400.png", 0.0, SOJU),
+                Drink.create("참이슬 오리지날", "charm-i-sel-soju", 20.1, "https://dmaxaug2ve9od.cloudfront.net/w_400/charm_i_sel_original_soju_w400.png", 0.0, SOJU),
+                Drink.create("진로", "jinro-soju", 16.5, "https://dmaxaug2ve9od.cloudfront.net/w_400/jinro_soju_w400.png", 0.0, SOJU),
 
                 // 와인
-                Drink.create("탈로 프리미티보 디 만두리아", "Talo Primitivo Di Manduria", 14.0, "w_400/Talo_Primitivo_Di_Manduria_w400.png", 0.0, WINE),
-                Drink.create("킴 크로포드, 피노 그리", "Kim Crawford, Pinot Gris", 13.0, "w_400/Kim_Crawford_Pinot_Gris_w400.png", 0.0, WINE),
-                Drink.create("커클랜드 시그니처 토니 포트 10년", "Kirkland Signature Tawny Port 10 years old", 20.0, "w_400/Kirkland_Signature_Tawny_Port_10_years_old_w400.png", 0.0, WINE),
-                Drink.create("버니니 클래식", "Bernini Classic", 4.5, "w_400/Bernini_Classic_w400.png", 0.0, WINE),
-                Drink.create("T7 까베르네 소비뇽", "T7 Cabernet Sauvignon", 13.0, "w_400/T7_Cabernet_Sauvignon_w400.png", 0.0, WINE),
-                Drink.create("복숭아 와인", "Peach Wine", 12.0, "w_400/Peach_Wine_w400.png", 0.0, WINE),
-                Drink.create("그란 띠에라 비노 블랑코", "Gran Tierra vino blanco", 10.5, "w_400/Gran_Tierra_vino_blanco_w400.png", 0.0, WINE),
-                Drink.create("비냐 란자 틴토", "VINA LANZAR Tinto", 11.5, "w_400/VINA_LANZAR_Tinto_w400.png", 0.0, WINE),
-                Drink.create("빈야드 샤도네이", "Vineyards Chardonnay", 13.0, "w_400/Vineyards_Chardonnay_w400.png", 0.0, WINE),
+                Drink.create("탈로 프리미티보 디 만두리아", "Talo Primitivo Di Manduria", 14.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Talo_Primitivo_Di_Manduria_w400.png", 0.0, WINE),
+                Drink.create("킴 크로포드, 피노 그리", "Kim Crawford, Pinot Gris", 13.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Kim_Crawford_Pinot_Gris_w400.png", 0.0, WINE),
+                Drink.create("커클랜드 시그니처 토니 포트 10년", "Kirkland Signature Tawny Port 10 years old", 20.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Kirkland_Signature_Tawny_Port_10_years_old_w400.png", 0.0, WINE),
+                Drink.create("버니니 클래식", "Bernini Classic", 4.5, "https://dmaxaug2ve9od.cloudfront.net/w_400/Bernini_Classic_w400.png", 0.0, WINE),
+                Drink.create("T7 까베르네 소비뇽", "T7 Cabernet Sauvignon", 13.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/T7_Cabernet_Sauvignon_w400.png", 0.0, WINE),
+                Drink.create("복숭아 와인", "Peach Wine", 12.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Peach_Wine_w400.png", 0.0, WINE),
+                Drink.create("그란 띠에라 비노 블랑코", "Gran Tierra vino blanco", 10.5, "https://dmaxaug2ve9od.cloudfront.net/w_400/Gran_Tierra_vino_blanco_w400.png", 0.0, WINE),
+                Drink.create("비냐 란자 틴토", "VINA LANZAR Tinto", 11.5, "https://dmaxaug2ve9od.cloudfront.net/w_400/VINA_LANZAR_Tinto_w400.png", 0.0, WINE),
+                Drink.create("빈야드 샤도네이", "Vineyards Chardonnay", 13.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Vineyards_Chardonnay_w400.png", 0.0, WINE),
 
                 // 막걸리
-                Drink.create("느린마을 막걸리", "Slow City Makgeolli", 6.0, "w_400/slowbrew_makgeulli_w400.png", 0.0, MAKGEOLLI),
-                Drink.create("과천미주", "Gwacheon Mijoo", 9.0, "w_400/Gwacheon_Mijoo_w400.png", 0.0, MAKGEOLLI),
-                Drink.create("관악산 생막걸리", "Gwanak Mountain Makgeolli", 6.0, "w_400/Gwanak_Mountain_Makgeolli_w400.png", 0.0, MAKGEOLLI),
-                Drink.create("국순당생막걸리", "Guksundang Makgeolli", 6.0, "w_400/Guksundang_Makgeolli_w400.png", 0.0, MAKGEOLLI),
-                Drink.create("경주법주 쌀막걸리", "GyeongjuBeopju Rice Makgeolli", 6.0, "w_400/Gyeongju_Beopju_Rice_Makgeolli_w400.png", 0.0, MAKGEOLLI),
-                Drink.create("소백산 막걸리", "Sobaeksan Makgeolli", 6.0, "w_400/Sobaeksan_Makgeolli_w400.png", 0.0, MAKGEOLLI),
-                Drink.create("대잎 동동주", "Bamboo Leaf Dongdongju", 6.0, "w_400/Bamboo_Leaf_Dongdongju_w400.png", 0.0, MAKGEOLLI),
+                Drink.create("느린마을 막걸리", "Slow City Makgeolli", 6.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/slowbrew_makgeulli_w400.png", 0.0, MAKGEOLLI),
+                Drink.create("과천미주", "Gwacheon Mijoo", 9.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Gwacheon_Mijoo_w400.png", 0.0, MAKGEOLLI),
+                Drink.create("관악산 생막걸리", "Gwanak Mountain Makgeolli", 6.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Gwanak_Mountain_Makgeolli_w400.png", 0.0, MAKGEOLLI),
+                Drink.create("국순당생막걸리", "Guksundang Makgeolli", 6.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Guksundang_Makgeolli_w400.png", 0.0, MAKGEOLLI),
+                Drink.create("경주법주 쌀막걸리", "GyeongjuBeopju Rice Makgeolli", 6.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Gyeongju_Beopju_Rice_Makgeolli_w400.png", 0.0, MAKGEOLLI),
+                Drink.create("소백산 막걸리", "Sobaeksan Makgeolli", 6.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Sobaeksan_Makgeolli_w400.png", 0.0, MAKGEOLLI),
+                Drink.create("대잎 동동주", "Bamboo Leaf Dongdongju", 6.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Bamboo_Leaf_Dongdongju_w400.png", 0.0, MAKGEOLLI),
 
                 // 양주
-                Drink.create("이엔제이 브랜디", "E&J Brandy", 40.0, "w_400/E&J_Brandy_w400.png", 0.0, YANGJU),
-                Drink.create("로얄 살루트 21 스카치 위스키", "Royal Salute 21 Year Old Blended Scotch Whisky", 40.0, "w_400/Royal_Salute_21_Year_Old_Blended_Scotch_Whisky_w400.png", 0.0, YANGJU),
-                Drink.create("발렌타인 12년산 베리 올드 블렌디드 스카치 위스키", "Ballantine's very old Scotch Whisky 21 Years", 43.0, "w_400/Ballantine's_very_old_Scotch_Whisky_21_Years_w400.png", 0.0, YANGJU),
-                Drink.create("스카치 블루 21년", "Scotch Blue 21years old", 40.0, "w_400/Scotch_Blue_21years_old_w400.png", 0.0, YANGJU),
-                Drink.create("까뮤XO 엘레강스", "Camus XO ELECANCE", 40.0, "w_400/Camus_XO_ELECANCE_w400.png", 0.0, YANGJU),
-                Drink.create("듀어스 18년산 블랜디드 스카치 위스키", "Dewar's 18 Blended Scotch Whisky", 40.0, "w_400/Dewar's_18_Blended_Scotch_Whisky_w400.png", 0.0, YANGJU),
-                Drink.create("글렌피딕 21년 리저바 럼 캐스크 피니쉬", "Glenfiddich 21years old Reserva Rum Cask Finish", 40.0, "w_400/Glenfiddich_21years_old_Reserva_Rum_Cask_Finish_w400.png", 0.0, YANGJU),
-                Drink.create("조니 워커 블랙 라벨 12년 산", "Johnnie Walker Black Label 12 Year Old", 40.0, "w_400/Johnnie_Walker_Black_Label_12_Year_Old_w400.png", 0.0, YANGJU),
+                Drink.create("이엔제이 브랜디", "E&J Brandy", 40.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/E&J_Brandy_w400.png", 0.0, YANGJU),
+                Drink.create("로얄 살루트 21 스카치 위스키", "Royal Salute 21 Year Old Blended Scotch Whisky", 40.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Royal_Salute_21_Year_Old_Blended_Scotch_Whisky_w400.png", 0.0, YANGJU),
+                Drink.create("발렌타인 12년산 베리 올드 블렌디드 스카치 위스키", "Ballantine's very old Scotch Whisky 21 Years", 43.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Ballantine's_very_old_Scotch_Whisky_21_Years_w400.png", 0.0, YANGJU),
+                Drink.create("스카치 블루 21년", "Scotch Blue 21years old", 40.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Scotch_Blue_21years_old_w400.png", 0.0, YANGJU),
+                Drink.create("까뮤XO 엘레강스", "Camus XO ELECANCE", 40.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Camus_XO_ELECANCE_w400.png", 0.0, YANGJU),
+                Drink.create("듀어스 18년산 블랜디드 스카치 위스키", "Dewar's 18 Blended Scotch Whisky", 40.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Dewar's_18_Blended_Scotch_Whisky_w400.png", 0.0, YANGJU),
+                Drink.create("글렌피딕 21년 리저바 럼 캐스크 피니쉬", "Glenfiddich 21years old Reserva Rum Cask Finish", 40.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Glenfiddich_21years_old_Reserva_Rum_Cask_Finish_w400.png", 0.0, YANGJU),
+                Drink.create("조니 워커 블랙 라벨 12년 산", "Johnnie Walker Black Label 12 Year Old", 40.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/Johnnie_Walker_Black_Label_12_Year_Old_w400.png", 0.0, YANGJU),
 
                 // 칵테일
-                Drink.create("그레이하운드", "Greyhound", 12.0, "w_400/greyhound_w400.png", 0.0, COCKTAIL),
-                Drink.create("올드 패션드", "Old Fashioned", 32.0, "w_400/oldfashioned_w400.png", 0.0, COCKTAIL),
-                Drink.create("마가리타", "Margarita", 23.0, "w_400/margarita_w400.png", 0.0, COCKTAIL),
-                Drink.create("블루 라군", "Blue Lagoon", 0.0, "w_400/bluelagoon_w400.png", 0.0, COCKTAIL),
-                Drink.create("솔티 독", "Salty Dog", 0.0, "w_400/saltydog_w400.png", 0.0, COCKTAIL),
-                Drink.create("섹스 온 더 비치", "Sex on the beach", 0.0, "w_400/sexonthebeach_w400.png", 0.0, COCKTAIL),
-                Drink.create("캘리포니아 레모네이드", "California Lemonade", 0.0, "w_400/calfornialemonade_w400.png", 0.0, COCKTAIL),
-                Drink.create("밥 말리", "Bob Marley", 0.0, "w_400/bobmarley_w400.png", 0.0, COCKTAIL),
-                Drink.create("브랜디 플립", "Brandy Flip", 0.0, "w_400/brandyflip_w400.png", 0.0, COCKTAIL),
-                Drink.create("샹그리아", "Sangria", 0.0, "w_400/sangria_w400.png", 0.0, COCKTAIL),
-                Drink.create("마티니", "Martini", 0.0, "w_400/martini_w400.png", 0.0, COCKTAIL),
+                Drink.create("그레이하운드", "Greyhound", 12.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/greyhound_w400.png", 0.0, COCKTAIL),
+                Drink.create("올드 패션드", "Old Fashioned", 32.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/oldfashioned_w400.png", 0.0, COCKTAIL),
+                Drink.create("마가리타", "Margarita", 23.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/margarita_w400.png", 0.0, COCKTAIL),
+                Drink.create("블루 라군", "Blue Lagoon", 0.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/bluelagoon_w400.png", 0.0, COCKTAIL),
+                Drink.create("솔티 독", "Salty Dog", 0.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/saltydog_w400.png", 0.0, COCKTAIL),
+                Drink.create("섹스 온 더 비치", "Sex on the beach", 0.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/sexonthebeach_w400.png", 0.0, COCKTAIL),
+                Drink.create("캘리포니아 레모네이드", "California Lemonade", 0.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/calfornialemonade_w400.png", 0.0, COCKTAIL),
+                Drink.create("밥 말리", "Bob Marley", 0.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/bobmarley_w400.png", 0.0, COCKTAIL),
+                Drink.create("브랜디 플립", "Brandy Flip", 0.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/brandyflip_w400.png", 0.0, COCKTAIL),
+                Drink.create("샹그리아", "Sangria", 0.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/sangria_w400.png", 0.0, COCKTAIL),
+                Drink.create("마티니", "Martini", 0.0, "https://dmaxaug2ve9od.cloudfront.net/w_400/martini_w400.png", 0.0, COCKTAIL),
 
                 // 기타
-                Drink.create("심술", "grumpy", 7.0, "w_400/simsul_w400.png", 0.0, ETC),
-                Drink.create("써머스비", "SomersBy", 4.5, "w_400/SomersBy_w400.png", 0.0, ETC),
-                Drink.create("템트 세븐", "Tempt 7", 4.5, "w_400/Tempt_7_w400.png", 0.0, ETC),
-                Drink.create("템트 9", "Tempt 9", 4.5, "w_400/Tempt_9_w400.png", 0.0, ETC),
-                Drink.create("복숭아 소다", "Peach Soda", 3.0, "w_400/Peach_Soda_w400.png", 0.0, ETC),
-                Drink.create("이슬 톡톡", "Jinro TokTok", 3.0, "w_400/Jinro_Tok_Tok_w400.png", 0.0, ETC),
-                Drink.create("좋은데이 민트초코", "jot-eun-day-mint-choco", 12.5, "w_400/jo_eun_day_mint_choco_w400.png", 0.0, ETC)
+                Drink.create("심술", "grumpy", 7.0, "https://dmaxaug2ve9od.cloudfront.netw_400/simsul_w400.png", 0.0, ETC),
+                Drink.create("써머스비", "SomersBy", 4.5, "https://dmaxaug2ve9od.cloudfront.netw_400/SomersBy_w400.png", 0.0, ETC),
+                Drink.create("템트 세븐", "Tempt 7", 4.5, "https://dmaxaug2ve9od.cloudfront.netw_400/Tempt_7_w400.png", 0.0, ETC),
+                Drink.create("템트 9", "Tempt 9", 4.5, "https://dmaxaug2ve9od.cloudfront.netw_400/Tempt_9_w400.png", 0.0, ETC),
+                Drink.create("복숭아 소다", "Peach Soda", 3.0, "https://dmaxaug2ve9od.cloudfront.netw_400/Peach_Soda_w400.png", 0.0, ETC),
+                Drink.create("이슬 톡톡", "Jinro TokTok", 3.0, "https://dmaxaug2ve9od.cloudfront.netw_400/Jinro_Tok_Tok_w400.png", 0.0, ETC),
+                Drink.create("좋은데이 민트초코", "jot-eun-day-mint-choco", 12.5,"https://dmaxaug2ve9od.cloudfront.net/w_400/jo_eun_day_mint_choco_w400.png", 0.0, ETC)
 
         );
 

--- a/backend/src/main/java/com/jujeol/drink/application/DrinkService.java
+++ b/backend/src/main/java/com/jujeol/drink/application/DrinkService.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -29,14 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DrinkService {
-
-    @Value("${file-server.url:}")
-    private String fileServerUrl;
-
     private final DrinkRepository drinkRepository;
     private final PreferenceRepository preferenceRepository;
     private final CategoryRepository categoryRepository;
-
 
     @LogWithTime
     public Page<DrinkDto> showDrinksBySearch(SearchDto searchDto, Pageable pageable) {
@@ -53,7 +47,7 @@ public class DrinkService {
         List<DrinkDto> drinkDtos = drinksBySearch.stream()
                 .distinct()
                 .map(drink -> DrinkDto.create(
-                        drink, Preference.create(drink, 0), fileServerUrl))
+                        drink, Preference.create(drink, 0)))
                 .collect(Collectors.toList());
 
         return new PageImpl<>(drinkDtos, pageable, drinksBySearch.size());
@@ -62,7 +56,7 @@ public class DrinkService {
     public Page<DrinkDto> showAllDrinksByPage(Pageable pageable) {
         List<DrinkDto> drinkDtos = drinkRepository.findAll(pageable).stream()
                 .map(drink -> DrinkDto.create(
-                        drink, Preference.create(drink, 0), fileServerUrl))
+                        drink, Preference.create(drink, 0)))
                 .collect(Collectors.toList());
 
         return new PageImpl<>(drinkDtos, pageable, drinkDtos.size());
@@ -75,7 +69,7 @@ public class DrinkService {
 
         List<DrinkDto> drinkDtos = recommendDrinks.stream()
                 .map(drink -> DrinkDto.create(
-                        drink, Preference.create(drink, 0), fileServerUrl))
+                        drink, Preference.create(drink, 0)))
                 .collect(Collectors.toList());
 
         return new PageImpl<>(drinkDtos, pageable, drinkDtos.size());
@@ -85,7 +79,7 @@ public class DrinkService {
         Drink drink = drinkRepository.findByIdWithFetch(id)
                 .orElseThrow(NotFoundDrinkException::new);
         Preference preference = Preference.create(drink, 0.0);
-        return DrinkDto.create(drink, preference, fileServerUrl);
+        return DrinkDto.create(drink, preference);
     }
 
     public DrinkDto showDrinkDetail(Long drinkId, Long memberId) {
@@ -94,7 +88,7 @@ public class DrinkService {
         Preference preference = preferenceRepository
                 .findByMemberIdAndDrinkId(memberId, drinkId)
                 .orElseGet(() -> Preference.anonymousPreference(drink));
-        return DrinkDto.create(drink, preference, fileServerUrl);
+        return DrinkDto.create(drink, preference);
     }
 
     @Transactional

--- a/backend/src/main/java/com/jujeol/drink/application/dto/DrinkDto.java
+++ b/backend/src/main/java/com/jujeol/drink/application/dto/DrinkDto.java
@@ -24,14 +24,13 @@ public class DrinkDto {
 
     public static DrinkDto create(
             Drink drink,
-            Preference preference,
-            String fileServerUrl
+            Preference preference
     ) {
         return new DrinkDto(drink.getId(),
                 drink.getName(),
                 drink.getEnglishName(),
                 drink.getAlcoholByVolume(),
-                fileServerUrl + "/" + drink.getImageFilePath(),
+                drink.getImageFilePath(),
                 CategoryDto.create(drink.getCategory()),
                 preference.getRate(),
                 drink.getPreferenceAvg()

--- a/backend/src/main/java/com/jujeol/member/application/MemberService.java
+++ b/backend/src/main/java/com/jujeol/member/application/MemberService.java
@@ -16,7 +16,6 @@ import com.jujeol.member.domain.PreferenceRepository;
 import com.jujeol.member.domain.nickname.Nickname;
 import com.jujeol.member.exception.NoSuchMemberException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -26,10 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberService {
-
-    @Value("${file-server.url:}")
-    private String fileServerUrl;
-
     private final MemberRepository memberRepository;
     private final PreferenceRepository preferenceRepository;
     private final DrinkRepository drinkRepository;
@@ -87,8 +82,7 @@ public class MemberService {
                 .findByMemberIdOrderByCreatedAtDesc(memberId, pageable)
                 .map(preference -> DrinkDto.create(
                         preference.getDrink(),
-                        preference,
-                        fileServerUrl
+                        preference
                         )
                 );
         return map;
@@ -100,8 +94,7 @@ public class MemberService {
                         review,
                         DrinkDto.create(
                                 review.getDrink(),
-                                Preference.create(review.getDrink(), 3.5),
-                                fileServerUrl
+                                Preference.create(review.getDrink(), 3.5)
                         )
                 ));
     }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,5 +1,3 @@
 logging:
   level:
     root: info
-file-server:
-  url: https://dmaxaug2ve9od.cloudfront.net

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -12,5 +12,3 @@ spring:
 logging:
   level:
     root: info
-file-server:
-  url: https://dmaxaug2ve9od.cloudfront.net

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,5 +1,3 @@
 logging:
   level:
     root: info
-file-server:
-  url: https://dmaxaug2ve9od.cloudfront.net


### PR DESCRIPTION
## resolve #291 

### 설명
- 이미지 파일패스 로직 수정
- 이미지 파일패스를 표현하는 로직 변경 및 DB 마이그레이션 코드 작성
- 다음 운영배포 때 다음 코드가 나가야 함 
``` 
update drink set image_file_path = concat('https://dmaxaug2ve9od.cloudfront.net/', image_file_path);
```

### 기타
