### PR TITLE
fix: 추천에 내가 마신 음료도 포함

### DIFF
--- a/backend/src/main/java/com/jujeol/commons/aop/LogAop.java
+++ b/backend/src/main/java/com/jujeol/commons/aop/LogAop.java
@@ -13,12 +13,14 @@ import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Component
 @Slf4j
 @RequiredArgsConstructor
+@Profile("!test")
 public class LogAop {
 
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/backend/src/main/java/com/jujeol/drink/application/RecommendFactory.java
+++ b/backend/src/main/java/com/jujeol/drink/application/RecommendFactory.java
@@ -4,6 +4,7 @@ import com.jujeol.drink.domain.RecommendForAnonymous;
 import com.jujeol.drink.domain.RecommendForMember;
 import com.jujeol.drink.domain.repository.DrinkRepository;
 import com.jujeol.drink.infrastructure.recommend.RecommendationSystem;
+import com.jujeol.member.domain.PreferenceRepository;
 import com.jujeol.member.ui.LoginMember;
 import java.util.EnumMap;
 import java.util.Map;
@@ -18,10 +19,10 @@ public class RecommendFactory {
     private final Map<MemberStatus, RecommendStrategy> recommendStrategyMap;
 
     public RecommendFactory(RecommendationSystem recommendationSystem,
-            DrinkRepository drinkRepository) {
+            DrinkRepository drinkRepository, PreferenceRepository preferenceRepository) {
         this.recommendStrategyMap = new EnumMap<>(MemberStatus.class);
         this.recommendStrategyMap.put(MemberStatus.ANONYMOUS, new RecommendForAnonymous(drinkRepository));
-        this.recommendStrategyMap.put(MemberStatus.MEMBER, new RecommendForMember(recommendationSystem, drinkRepository));
+        this.recommendStrategyMap.put(MemberStatus.MEMBER, new RecommendForMember(recommendationSystem, drinkRepository, preferenceRepository));
     }
 
     public RecommendStrategy create(LoginMember loginMember) {

--- a/backend/src/main/java/com/jujeol/drink/application/RecommendFactory.java
+++ b/backend/src/main/java/com/jujeol/drink/application/RecommendFactory.java
@@ -19,7 +19,9 @@ public class RecommendFactory {
     private final Map<MemberStatus, RecommendStrategy> recommendStrategyMap;
 
     public RecommendFactory(RecommendationSystem recommendationSystem,
-            DrinkRepository drinkRepository, PreferenceRepository preferenceRepository) {
+            DrinkRepository drinkRepository, 
+            PreferenceRepository preferenceRepository
+            ) {
         this.recommendStrategyMap = new EnumMap<>(MemberStatus.class);
         this.recommendStrategyMap.put(MemberStatus.ANONYMOUS, new RecommendForAnonymous(drinkRepository));
         this.recommendStrategyMap.put(MemberStatus.MEMBER, new RecommendForMember(recommendationSystem, drinkRepository, preferenceRepository));

--- a/backend/src/main/java/com/jujeol/drink/domain/RecommendForAnonymous.java
+++ b/backend/src/main/java/com/jujeol/drink/domain/RecommendForAnonymous.java
@@ -3,10 +3,8 @@ package com.jujeol.drink.domain;
 import com.jujeol.drink.application.RecommendStrategy;
 import com.jujeol.drink.domain.repository.DrinkRepository;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 
 @RequiredArgsConstructor
 public class RecommendForAnonymous implements RecommendStrategy {

--- a/backend/src/main/java/com/jujeol/drink/domain/RecommendForMember.java
+++ b/backend/src/main/java/com/jujeol/drink/domain/RecommendForMember.java
@@ -3,6 +3,9 @@ package com.jujeol.drink.domain;
 import com.jujeol.drink.application.RecommendStrategy;
 import com.jujeol.drink.domain.repository.DrinkRepository;
 import com.jujeol.drink.infrastructure.recommend.RecommendationSystem;
+import com.jujeol.member.domain.Preference;
+import com.jujeol.member.domain.PreferenceRepository;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -13,24 +16,51 @@ public class RecommendForMember implements RecommendStrategy {
 
     private final RecommendationSystem recommendationSystem;
     private final DrinkRepository drinkRepository;
+    private final PreferenceRepository preferenceRepository;
 
     @Override
     public List<Drink> recommend(Long memberId, int pageSize) {
-        final List<Long> itemIds = recommendationSystem.recommend(memberId, pageSize);
+        List<Preference> preferences = preferenceRepository.findAll();
+        final List<Long> itemIds = recommendationSystem.recommend(memberId, pageSize, preferences);
+        final List<Long> triedItems = preferences.stream()
+                .filter(preference -> preference.getMember().getId().equals(memberId))
+                .map(preference -> preference.getDrink().getId())
+                .collect(Collectors.toList());
 
         List<Drink> drinks = drinkRepository.findAllById(itemIds);
+        drinks = setFirstNoTriedItem(drinks, triedItems);
 
         if (itemIds.size() < pageSize) {
-            return addDrinkByPreferenceAvg(drinks, memberId, pageSize);
+            addItemByPreferenceAvg(drinks, triedItems, pageSize);
         }
 
         return drinks;
     }
 
-    private List<Drink> addDrinkByPreferenceAvg(List<Drink> drinks, Long memberId, int pageSize) {
-        drinks.addAll(drinkRepository.findDrinksForMember(memberId, Pageable.ofSize(pageSize)));
-        return drinks.stream().distinct()
-                .limit(pageSize)
-                .collect(Collectors.toList());
+    private void addItemByPreferenceAvg(List<Drink> drinks, List<Long> triedItems, int pageSize) {
+        List<Drink> drinksByPreference = drinkRepository
+                .findDrinks(Pageable.ofSize(pageSize));
+        drinksByPreference = setFirstNoTriedItem(drinksByPreference, triedItems);
+        for (Drink drink : drinksByPreference) {
+            if (drinks.size() < pageSize && !drinks.contains(drink)) {
+                drinks.add(drink);
+            }
+        }
+    }
+
+    private List<Drink> setFirstNoTriedItem(List<Drink> drinks, List<Long> triedItems) {
+        LinkedList<Drink> triedDrinks = new LinkedList<>();
+        for (Drink drink : drinks) {
+            addDrinkByCheckingTriedOrNot(triedItems, triedDrinks, drink);
+        }
+        return triedDrinks;
+    }
+
+    private void addDrinkByCheckingTriedOrNot(List<Long> triedItems, LinkedList<Drink> triedDrinks, Drink drink) {
+        if(triedItems.contains(drink.getId())) {
+            triedDrinks.addLast(drink);
+            return;
+        }
+        triedDrinks.addFirst(drink);
     }
 }

--- a/backend/src/main/java/com/jujeol/drink/infrastructure/recommend/RecommendationSystem.java
+++ b/backend/src/main/java/com/jujeol/drink/infrastructure/recommend/RecommendationSystem.java
@@ -27,9 +27,13 @@ public class RecommendationSystem {
 
     public List<Long> recommend(Long memberId, int howMany) {
         final List<Preference> preferences = preferenceRepository.findAll();
+        return recommend(memberId, howMany, preferences);
+    }
+
+    public List<Long> recommend(Long memberId, int howMany, List<Preference> preferences) {
         final UserBasedRecommender recommender = getRecommender(preferences);
         try {
-            return recommender.recommend(memberId, howMany, false)
+            return recommender.recommend(memberId, howMany, true)
                     .stream()
                     .mapToLong(RecommendedItem::getItemID)
                     .boxed()

--- a/backend/src/test/java/com/jujeol/drink/acceptance/DrinkAcceptanceTest.java
+++ b/backend/src/test/java/com/jujeol/drink/acceptance/DrinkAcceptanceTest.java
@@ -103,10 +103,9 @@ public class DrinkAcceptanceTest extends AcceptanceTest {
                 .build().convertBodyToList(DrinkSimpleResponse.class);
 
         //then
-        drinkSimpleResponses.forEach(drinkSimpleResponse -> System.out.println(drinkSimpleResponse.getName()));
-        assertThat(drinkSimpleResponses.get(0).getName()).isEqualTo("애플");
+        assertThat(drinkSimpleResponses.get(0).getName()).isEqualTo("타이거 라들러 자몽");
         assertThat(drinkSimpleResponses.get(1).getName()).isEqualTo("타이거 라들러 레몬");
-        assertThat(drinkSimpleResponses.get(2).getName()).isEqualTo("타이거 라들러 자몽");
+        assertThat(drinkSimpleResponses.get(2).getName()).isEqualTo("애플");
     }
 
     private void 협업_필터링_데이터_등록() {


### PR DESCRIPTION
## related #125 

### 설명
- 기존엔 내가 마신 음료는 포함하지 않고 추천하게 되었음.
- 내가 마셨더라도 추천에 포함되게끔 정책 변경.

#### 추천 음료 순서 순 : 
- 협업 필터링 추천 (내가 마시지 않은 술) -> 협업 필터링 추천 (이미 마셔본 술) -> 선호도 평균 순 (내가 마시지 않은 술) -> 선호도 평균 순 (이미 마셔본 술)
