### PR TITLE
config: file-logging 에 컬러 옵션을 제거

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -6,6 +6,7 @@
   <property name="LOG_FILE_NAME" value="jujeol"/>
   <!-- pattern -->
   <property name="LOG_PATTERN" value="%white(%d{HH:mm:ss.SSS}) %cyan([%thread]) %highlight([%-5level]) %yellow([%logger{0}]) - %boldWhite(%m%n)"/>
+  <property name="LOG_FILE_PATTERN" value="%d{HH:mm:ss.SSS} [%thread] [%-5level] [%logger{0}] - %m%n"/>
 
   <springProfile name="console-logging">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -19,7 +20,7 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
       <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
       <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-        <pattern>${LOG_PATTERN}</pattern>
+        <pattern>${LOG_FILE_PATTERN}</pattern>
       </encoder>
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
         <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.zip</fileNamePattern>


### PR DESCRIPTION
## resolve #308 

### 설명
- CloudWatch에 컬러가 깨지는 이슈가 있어 file-logging의 로그 패턴을 변경했습니다.

### 기타
