### PR TITLE
fix: 상세페이지 페이지 상단 이동 스크롤 조정 및 비로그인 사용자 선호도 입력하러 가기 버튼 기능 제한

### DIFF
--- a/frontend/src/components/Review/DisableWriteReview.tsx
+++ b/frontend/src/components/Review/DisableWriteReview.tsx
@@ -6,10 +6,10 @@ import { COLOR } from 'src/constants';
 import Arrow from '../@shared/Arrow/Arrow';
 
 interface Props {
-  onMoveToPreferenceSection: MouseEventHandler<HTMLButtonElement>;
+  onNoticeToInputPreference: MouseEventHandler<HTMLButtonElement>;
 }
 
-const DisableWriteReview = ({ onMoveToPreferenceSection }: Props) => {
+const DisableWriteReview = ({ onNoticeToInputPreference }: Props) => {
   return (
     <Container>
       <Card
@@ -21,7 +21,7 @@ const DisableWriteReview = ({ onMoveToPreferenceSection }: Props) => {
         <p>
           먼저 <strong>선호도</strong>를 입력해주세요!
         </p>
-        <button type="button" onClick={onMoveToPreferenceSection}>
+        <button type="button" onClick={onNoticeToInputPreference}>
           선호도 입력하러 가기
           <Arrow size="0.5rem" dir="UP" color={`${COLOR.BLACK_900}`} />
         </button>

--- a/frontend/src/components/Review/Review.tsx
+++ b/frontend/src/components/Review/Review.tsx
@@ -14,10 +14,10 @@ interface Props {
   drinkId: string;
   drinkName: string;
   preferenceRate: number;
-  onMoveToPreferenceSection: MouseEventHandler<HTMLButtonElement>;
+  onNoticeToInputPreference: MouseEventHandler<HTMLButtonElement>;
 }
 
-const Review = ({ drinkId, drinkName, preferenceRate, onMoveToPreferenceSection }: Props) => {
+const Review = ({ drinkId, drinkName, preferenceRate, onNoticeToInputPreference }: Props) => {
   const observerTargetRef = useRef<HTMLDivElement>(null);
 
   const { reviews, totalSize, fetchNextPage, hasNextPage } = useReviews({ drinkId });
@@ -29,7 +29,7 @@ const Review = ({ drinkId, drinkName, preferenceRate, onMoveToPreferenceSection 
       {preferenceRate ? (
         <ReviewCreateForm />
       ) : (
-        <DisableWriteReview onMoveToPreferenceSection={onMoveToPreferenceSection} />
+        <DisableWriteReview onNoticeToInputPreference={onNoticeToInputPreference} />
       )}
 
       {totalSize === 0 ? (

--- a/frontend/src/hooks/useInputPreference.ts
+++ b/frontend/src/hooks/useInputPreference.ts
@@ -1,0 +1,38 @@
+import { useState, RefObject } from 'react';
+
+const useNoticeToInputPreference = ({ targetRef }: { targetRef: RefObject<HTMLDivElement> }) => {
+  const [isBlinked, setIsBlinked] = useState(false);
+
+  const scrollToPreferenceSection = () => {
+    targetRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) {
+          scrollToPreferenceSection();
+        } else {
+          observer.disconnect();
+        }
+
+        setIsBlinked(true);
+      });
+    },
+    { threshold: 1.0 }
+  );
+
+  const observePreferenceSection = () => {
+    if (targetRef.current) {
+      observer.observe(targetRef.current);
+    }
+
+    setTimeout(() => {
+      setIsBlinked(false);
+    }, 3000);
+  };
+
+  return { isBlinked, setIsBlinked, observePreferenceSection };
+};
+
+export default useNoticeToInputPreference;

--- a/frontend/src/pages/DrinksDetailPage/NotAuthorized.test.tsx
+++ b/frontend/src/pages/DrinksDetailPage/NotAuthorized.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { customRender } from 'src/tests/customRenderer';
-import { MockIntersectionObserver, mockScrollTo } from 'src/tests/mockTestFunction';
+import { MockIntersectionObserver } from 'src/tests/mockTestFunction';
 import { drinksDetail } from 'src/mocks/drinksDetail';
 import { drinksReviews } from 'src/mocks/drinksReviews';
 import API from 'src/apis/requests';
@@ -12,7 +12,7 @@ import DrinksDetailPage from '.';
 
 describe('로그인 되지 않은 사용자가 상세페이지를 이용한다.', () => {
   beforeEach(async () => {
-    Object.defineProperty(global.window, 'scrollTo', { value: mockScrollTo });
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
     Object.defineProperty(global.window, 'IntersectionObserver', {
       value: MockIntersectionObserver,
     });

--- a/frontend/src/pages/DrinksDetailPage/index.tsx
+++ b/frontend/src/pages/DrinksDetailPage/index.tsx
@@ -13,6 +13,7 @@ import { Section, PreferenceSection, Image, DescriptionSection, Container } from
 import { COLOR, ERROR_MESSAGE, MESSAGE, PATH, PREFERENCE } from 'src/constants';
 import Skeleton from 'src/components/@shared/Skeleton/Skeleton';
 import DrinksDetailDescriptionSkeleton from 'src/components/Skeleton/DrinksDetailDescriptionSkeleton';
+import useNoticeToInputPreference from 'src/hooks/useInputPreference';
 
 const defaultDrinkDetail = {
   name: 'name',
@@ -36,7 +37,6 @@ const DrinksDetailPage = () => {
   const pageContainerRef = useRef<HTMLImageElement>(null);
   const preferenceRef = useRef<HTMLDivElement>(null);
 
-  const [isBlinked, setIsBlinked] = useState(false);
   const [currentPreferenceRate, setCurrentPreferenceRate] = useState(
     defaultDrinkDetail.preferenceRate
   );
@@ -84,6 +84,10 @@ const DrinksDetailPage = () => {
     }
   );
 
+  const { isBlinked, setIsBlinked, observePreferenceSection } = useNoticeToInputPreference({
+    targetRef: preferenceRef,
+  });
+
   const setPreferenceRate = (value: number) => {
     setCurrentPreferenceRate(value);
   };
@@ -107,17 +111,13 @@ const DrinksDetailPage = () => {
     }
   };
 
-  const onMoveToPreferenceSection: MouseEventHandler<HTMLButtonElement> = () => {
+  const onNoticeToInputPreference: MouseEventHandler<HTMLButtonElement> = () => {
     if (!isLoggedIn) {
       moveToLoginPage();
-    } else {
-      setIsBlinked(true);
-      preferenceRef.current?.scrollIntoView({ behavior: 'smooth' });
-
-      setTimeout(() => {
-        setIsBlinked(false);
-      }, 3000);
+      return;
     }
+
+    observePreferenceSection();
   };
 
   return (
@@ -177,7 +177,7 @@ const DrinksDetailPage = () => {
           drinkId={drinkId}
           drinkName={name}
           preferenceRate={currentPreferenceRate}
-          onMoveToPreferenceSection={onMoveToPreferenceSection}
+          onNoticeToInputPreference={onNoticeToInputPreference}
         />
       </Section>
     </Container>

--- a/frontend/src/pages/DrinksDetailPage/index.tsx
+++ b/frontend/src/pages/DrinksDetailPage/index.tsx
@@ -97,7 +97,7 @@ const DrinksDetailPage = () => {
   const onCheckLoggedIn = () => {
     setIsBlinked(false);
     if (!isLoggedIn) {
-      moveToLoginPage;
+      moveToLoginPage();
     }
   };
 
@@ -109,7 +109,7 @@ const DrinksDetailPage = () => {
 
   const onMoveToPreferenceSection: MouseEventHandler<HTMLButtonElement> = () => {
     if (!isLoggedIn) {
-      moveToLoginPage;
+      moveToLoginPage();
     } else {
       setIsBlinked(true);
       preferenceRef.current?.scrollIntoView({ behavior: 'smooth' });

--- a/frontend/src/pages/DrinksDetailPage/index.tsx
+++ b/frontend/src/pages/DrinksDetailPage/index.tsx
@@ -87,12 +87,16 @@ const DrinksDetailPage = () => {
     setCurrentPreferenceRate(value);
   };
 
+  const moveToLoginPage = () => {
+    if (confirm(MESSAGE.LOGIN_REQUIRED_TO_UPDATE_PREFERENCE)) {
+      history.push(PATH.LOGIN);
+    }
+  };
+
   const onCheckLoggedIn = () => {
     setIsBlinked(false);
     if (!isLoggedIn) {
-      if (confirm(MESSAGE.LOGIN_REQUIRED_TO_UPDATE_PREFERENCE)) {
-        history.push(PATH.LOGIN);
-      }
+      moveToLoginPage;
     }
   };
 
@@ -103,14 +107,16 @@ const DrinksDetailPage = () => {
   };
 
   const onMoveToPreferenceSection: MouseEventHandler<HTMLButtonElement> = () => {
-    onCheckLoggedIn();
+    if (!isLoggedIn) {
+      moveToLoginPage;
+    } else {
+      setIsBlinked(true);
+      preferenceRef.current?.scrollIntoView({ behavior: 'smooth' });
 
-    setIsBlinked(true);
-    preferenceRef.current?.scrollIntoView({ behavior: 'smooth' });
-
-    setTimeout(() => {
-      setIsBlinked(false);
-    }, 3000);
+      setTimeout(() => {
+        setIsBlinked(false);
+      }, 3000);
+    }
   };
 
   return (

--- a/frontend/src/pages/DrinksDetailPage/index.tsx
+++ b/frontend/src/pages/DrinksDetailPage/index.tsx
@@ -33,6 +33,7 @@ const DrinksDetailPage = () => {
 
   const history = useHistory();
 
+  const pageContainerRef = useRef<HTMLImageElement>(null);
   const preferenceRef = useRef<HTMLDivElement>(null);
 
   const [isBlinked, setIsBlinked] = useState(false);
@@ -43,7 +44,7 @@ const DrinksDetailPage = () => {
   const isLoggedIn = useContext(UserContext)?.isLoggedIn;
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    pageContainerRef.current?.scrollIntoView();
   }, []);
 
   const { data: { data: drink = defaultDrinkDetail } = {}, isLoading } = useQuery(
@@ -120,7 +121,7 @@ const DrinksDetailPage = () => {
   };
 
   return (
-    <Container>
+    <Container ref={pageContainerRef}>
       <GoBackButton color={COLOR.BLACK_900} />
       {isLoading ? (
         <Skeleton width="100" height="30rem" />

--- a/frontend/src/pages/DrinksDetailPage/test.tsx
+++ b/frontend/src/pages/DrinksDetailPage/test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { customRender } from 'src/tests/customRenderer';
-import { MockIntersectionObserver, mockScrollTo } from 'src/tests/mockTestFunction';
+import { MockIntersectionObserver } from 'src/tests/mockTestFunction';
 import { validateMember } from 'src/mocks/member';
 import { drinksDetail } from 'src/mocks/drinksDetail';
 import { drinksReviews } from 'src/mocks/drinksReviews';
@@ -13,7 +13,7 @@ import DrinksDetailPage from '.';
 
 describe('로그인 된 사용자가 상세페이지를 이용한다.', () => {
   beforeAll(async () => {
-    Object.defineProperty(global.window, 'scrollTo', { value: mockScrollTo });
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
     Object.defineProperty(global.window, 'IntersectionObserver', {
       value: MockIntersectionObserver,
     });


### PR DESCRIPTION
## resolve #321 

### 설명
- container에 ref를 사용하여, 상세페이지 페이지 상단 이동 스크롤 조정
- 조건문을 통한 비로그인가 '선호도 입력하러 가기' 버튼을 선택했을 때 alert 기능만이 활성화되도록 조정
<img width="349" src="https://user-images.githubusercontent.com/59258239/129021412-5fa2de23-5547-4c74-a4e8-5dbfffbcc46e.gif">
<img width="450" src="https://user-images.githubusercontent.com/59258239/129021417-308100e2-2d06-46f2-896c-2ce621343ff1.gif">


### 기타
- ~~이미 선호도가 화면상에 있는데도 불구하고 스크롤이 내려가는 부분에 대해서는 고려해야하는 점이 많아서, 추후에 '선호도 입력하러 가기'를 리팩토링 할 때 다시 시도해보겠습니다.~~ => 해결했습니다
