### PR TITLE
refactor: 홈페이지의 검색바 autofocus 기능 해제

### DIFF
--- a/frontend/src/components/@shared/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/@shared/SearchBar/SearchBar.tsx
@@ -8,6 +8,7 @@ import { Container, ResetButton, SearchButton, SearchInput } from './SearchBar.s
 const SearchBar = ({
   onClick,
   placeholder,
+  readOnly,
 }: InputHTMLAttributes<HTMLInputElement | HTMLFormElement>) => {
   const history = useHistory();
   const location = useLocation();
@@ -51,6 +52,7 @@ const SearchBar = ({
         maxLength={SEARCH.MAX_LENGTH}
         required
         autoFocus
+        readOnly={readOnly}
       />
       {!isMainPage && (
         <>

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -15,7 +15,7 @@ const HomePage = () => {
   return (
     <div>
       <MainHeader />
-      <SearchBar onClick={onMoveToSearchPage} placeholder="검색어를 입력해주세요" />
+      <SearchBar onClick={onMoveToSearchPage} placeholder="검색어를 입력해주세요" readOnly={true} />
 
       <Grid rowGap="2rem" colMin="280px" colMax="480px">
         {config.map((section: ItemList | BannerType) => {

--- a/frontend/src/pages/SearchPage/index.tsx
+++ b/frontend/src/pages/SearchPage/index.tsx
@@ -61,7 +61,7 @@ const SearchPage = ({ history }: RouteComponentProps) => {
 
   return (
     <Container>
-      <SearchBar placeholder="검색어를 입력해주세요" />
+      <SearchBar placeholder="검색어를 입력해주세요" readOnly={false} />
 
       <Categories>
         <h3>카테고리</h3>


### PR DESCRIPTION
## resolve #324 

### 설명
- searchBar 컴포넌트에 readOnly props를 사용하여 메인페이지에서는 true, 검색페이지에서는 false를 전달
- 메인페이지에서는 autoFocus 기능을 제한하고, 검색페이지에서만 활성화 되도록 조정
