### PR TITLE
fix: 검색어에 카테고리명 입력 시 모든 주류를 반환하는 오류 해결

### DIFF
--- a/backend/src/main/java/com/jujeol/drink/drink/domain/repository/DrinkRepositoryImpl.java
+++ b/backend/src/main/java/com/jujeol/drink/drink/domain/repository/DrinkRepositoryImpl.java
@@ -50,13 +50,14 @@ public class DrinkRepositoryImpl implements DrinkCustomRepository {
     private BooleanBuilder searchCondition(SearchWords searchWords, List<String> categoryNames) {
         BooleanBuilder builder = new BooleanBuilder();
         if (searchWords.hasSearchWords()) {
-            searchWords.getSearchWords()
-                    .stream()
-                    .filter(s -> !categoryNames.contains(s))
-                    .forEach(word -> {
-                        builder.or(drink.name.name.likeIgnoreCase("%" + word + "%"));
-                        builder.or(drink.englishName.englishName.likeIgnoreCase("%" + word + "%"));
-                    });
+            for (String word : searchWords.getSearchWords()) {
+                if (categoryNames.contains(word)) {
+                    builder.or(drink.name.name.eq("절대절대절대검색되지않고세상에존재하지않는이름"));
+                    continue;
+                }
+                builder.or(drink.name.name.likeIgnoreCase("%" + word + "%"));
+                builder.or(drink.englishName.englishName.likeIgnoreCase("%" + word + "%"));
+            }
         }
         return builder;
     }

--- a/backend/src/test/java/com/jujeol/drink/acceptance/DrinkAcceptanceTest.java
+++ b/backend/src/test/java/com/jujeol/drink/acceptance/DrinkAcceptanceTest.java
@@ -196,9 +196,6 @@ public class DrinkAcceptanceTest extends AcceptanceTest {
                 .build();
 
         //then
-        final List<DrinkSimpleResponse> drinkSimpleResponses =
-                httpResponse.convertBodyToList(DrinkSimpleResponse.class);
-
         final List<String> drinkNames =
                 asNames(KGB, STELLA, APPLE, ESTP, OB, TIGER_LEMON, TIGER_RAD, TSINGTAO);
 


### PR DESCRIPTION
## resolve #323

### 설명
- `절대절대없는이름`으로 한 번 검증하는 로직 추가

### 기타
- 추후 리팩토링 예정