### PR TITLE
feat: 프론트엔드 성능 최적화

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -17,6 +17,11 @@
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&display=swap"
+    rel="stylesheet">
+
   <!-- Global site tag (gtag.js) - Google Analytics only for prod -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8EM73DMKBC"></script>
   <script>
@@ -26,21 +31,6 @@
 
     gtag('config', 'G-8EM73DMKBC');
   </script>
-
-  <!-- Jenifer front for estimation -->
-  <script>
-    (function (j, en, ni, fer) {
-      j['dmndata'] = []; j['jenniferFront'] = function (args) { window.dmndata.push(args) };
-      j['dmnaid'] = fer; j['dmnatime'] = new Date(); j['dmnanocookie'] = false; j['dmnajennifer'] = 'JENNIFER_FRONT@INTG';
-      var b = Math.floor(new Date().getTime() / 60000) * 60000; var a = en.createElement(ni);
-      a.src = 'https://d-collect.jennifersoft.com/' + fer + '/demian.js?' + b; a.async = true;
-      en.getElementsByTagName(ni)[0].parentNode.appendChild(a);
-    }(window, document, 'script', 'e0fa53f0'));
-  </script>
-
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&display=swap" rel="stylesheet">
 
   <title>주절주절</title>
 </head>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,21 @@
+import { lazy, Suspense } from 'react';
 import { BrowserRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
+
 import ModalProvider from './components/Modal/ModalProvider';
 import Tab from './components/Tab/Tab';
 import PATH from './constants/path';
-import DrinksDetailPage from './pages/DrinksDetailPage';
-import HomePage from './pages/HomePage';
-import LoginPage from './pages/LoginPage';
-import OauthPage from './pages/OauthPage';
-import MyPage from './pages/MyPage';
-import ViewAllPage from './pages/ViewAllPage';
-import MyDrinksPage from './pages/MyDrinksPage';
-import MyReviewsPage from './pages/MyReviewsPage';
-import SearchPage from './pages/SearchPage';
-import SearchResultPage from './pages/SearchResultPage';
 import { MainContainer } from './styles';
+
+const HomePage = lazy(() => import('./pages/HomePage'));
+const LoginPage = lazy(() => import('./pages/LoginPage'));
+const OauthPage = lazy(() => import('./pages/OauthPage'));
+const DrinksDetailPage = lazy(() => import('./pages/DrinksDetailPage'));
+const MyPage = lazy(() => import('./pages/MyPage'));
+const ViewAllPage = lazy(() => import('./pages/ViewAllPage'));
+const MyDrinksPage = lazy(() => import('./pages/MyDrinksPage'));
+const MyReviewsPage = lazy(() => import('./pages/MyReviewsPage'));
+const SearchPage = lazy(() => import('./pages/SearchPage'));
+const SearchResultPage = lazy(() => import('./pages/SearchResultPage'));
 
 const App = () => {
   return (
@@ -21,17 +24,19 @@ const App = () => {
         <ModalProvider>
           <MainContainer>
             <Switch>
-              <Route exact path={[PATH.HOME, PATH.ROOT]} component={HomePage} />
-              <Route exact path={[PATH.LOGIN]} component={LoginPage} />
-              <Route exact path={[PATH.OAUTH]} component={OauthPage} />
-              <Route exact path={[PATH.VIEW_ALL]} component={ViewAllPage} />
-              <Route exact path={`${PATH.DRINKS}/:id`} component={DrinksDetailPage} />
-              <Route exact path={[PATH.MYPAGE]} component={MyPage} />
-              <Route exact path={[PATH.MY_DRINKS]} component={MyDrinksPage} />
-              <Route exact path={[PATH.MY_REVIEWS]} component={MyReviewsPage} />
-              <Route exact path={[PATH.SEARCH]} component={SearchPage} />
-              <Route exact path={[PATH.SEARCH_RESULT]} component={SearchResultPage} />
-              <Redirect to={PATH.ROOT} />
+              <Suspense fallback>
+                <Route exact path={[PATH.HOME, PATH.ROOT]} component={HomePage} />
+                <Route exact path={[PATH.LOGIN]} component={LoginPage} />
+                <Route exact path={[PATH.OAUTH]} component={OauthPage} />
+                <Route exact path={[PATH.VIEW_ALL]} component={ViewAllPage} />
+                <Route exact path={`${PATH.DRINKS}/:id`} component={DrinksDetailPage} />
+                <Route exact path={[PATH.MYPAGE]} component={MyPage} />
+                <Route exact path={[PATH.MY_DRINKS]} component={MyDrinksPage} />
+                <Route exact path={[PATH.MY_REVIEWS]} component={MyReviewsPage} />
+                <Route exact path={[PATH.SEARCH]} component={SearchPage} />
+                <Route exact path={[PATH.SEARCH_RESULT]} component={SearchResultPage} />
+                <Redirect to={PATH.ROOT} />
+              </Suspense>
             </Switch>
           </MainContainer>
         </ModalProvider>

--- a/frontend/src/components/Banner/Banner.styles.ts
+++ b/frontend/src/components/Banner/Banner.styles.ts
@@ -4,6 +4,7 @@ import { COLOR } from 'src/constants';
 const Container = styled.section`
   width: 100%;
   height: fit-content;
+  min-height: 196px;
   position: relative;
 
   h2 {
@@ -15,6 +16,7 @@ const Container = styled.section`
 
   img {
     width: 100%;
+    height: 100%;
     background-color: ${COLOR.WHITE_200};
     object-fit: cover;
   }


### PR DESCRIPTION
## resolve #355 

### 설명
프론트엔트 성능 최적화를 진행하였습니다.
- [x] 각 페이지에 React.lazy 적용
- [x] 폰트 preload 하기
- [x] 배너 이미지 width, height 지정하기
- [x]  s3에 저장되어 있는 사용하는 사진에 대해서 cache-control 을 추가
<img width="1056" alt="스크린샷 2021-09-16 오후 4 39 49" src="https://user-images.githubusercontent.com/59258239/133570840-80c10e34-2d4b-45f4-88c8-d0bac9d69b4e.png">

### 기타
앞으로 해야하는 일
- [ ] 이미지 최적화 (포멧 변경 및 캐싱 정책 적용)
- [ ] js 파일 캐싱 정책 적용
- [ ] reflow 덜 일어나게 css 정리
- [ ] Test mock 파일 번들에서 제외하기
- [ ] 컴포넌트에서 안쓰이는 레거시 코드 파일 제거하기 
- [ ] Defualt 이미지 정책 정하고, 기존의 이미지 삭제하기
- [ ] 상세페이지, 검색결과 페이지, 마이페이지 성능 측정하기
- [ ] font 스타일 화해서 안쓰이는 weight 삭제하기