### PR TITLE
feat: 주류 상세페이지 상세 설명 추가 및 이미지 리사이징 기능 구현

### DIFF
--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -120,16 +120,16 @@ const GlobalStyle = () => (
         }
       }
 
+      @media screen and (max-width: 320px) {
+        html,
+        body,
+        #root {
+          font-size: 14px;
+        }
+      }
+
       input {
         -webkit-tap-highlight-color: transparent;
-
-        @media screen and (max-width: 320px) {
-          html,
-          body,
-          #root {
-            font-size: 14px;
-          }
-        }
       }
     `}
   />

--- a/frontend/src/components/Card/ReviewCard.styles.ts
+++ b/frontend/src/components/Card/ReviewCard.styles.ts
@@ -34,7 +34,7 @@ const ReviewerInfo = styled.div`
   }
 `;
 
-const Content = styled.div<{ isContentOpen: boolean }>`
+const Content = styled.p<{ isContentOpen: boolean }>`
   text-align: justify;
   white-space: break-spaces;
 

--- a/frontend/src/components/Card/ReviewCard.tsx
+++ b/frontend/src/components/Card/ReviewCard.tsx
@@ -1,7 +1,8 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { COLOR } from 'src/constants';
 import UserContext from 'src/contexts/UserContext';
+import useShowMoreContent from 'src/hooks/useShowMoreContent';
 import Card from '../@shared/Card/Card';
 import {
   LoveEmojiColorIcon,
@@ -32,23 +33,10 @@ const ReviewCard = ({ review }: Props) => {
   const openModal = useContext(modalContext)?.openModal;
   const { userData } = useContext(UserContext);
 
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [isShowMore, setIsShowMore] = useState(false);
-  const [isContentOpen, setIsContentOpen] = useState(false);
+  const contentRef = useRef<HTMLParagraphElement>(null);
+  const { isShowMore, isContentOpen, onOpenContent } = useShowMoreContent(contentRef, content);
 
   const UserProfileIcon = userProfileIcons[author.id % 4];
-
-  useEffect(() => {
-    const content = contentRef.current;
-    if (content) {
-      setIsShowMore(content.clientHeight < content.scrollHeight);
-    }
-  }, [contentRef, content]);
-
-  const onShowMore = () => {
-    setIsShowMore(false);
-    setIsContentOpen(true);
-  };
 
   const onOpenEditForm = () => {
     openModal?.(<ReviewEditForm drinkId={drinkId} review={review} />);
@@ -69,7 +57,7 @@ const ReviewCard = ({ review }: Props) => {
       <Content ref={contentRef} isContentOpen={isContentOpen}>
         {content}
       </Content>
-      {isShowMore && <ShowMoreButton onClick={onShowMore} />}
+      {isShowMore && !isContentOpen && <ShowMoreButton onClick={onOpenContent} />}
     </Card>
   );
 };

--- a/frontend/src/hooks/useShowMoreContent.ts
+++ b/frontend/src/hooks/useShowMoreContent.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState, RefObject, MouseEventHandler } from 'react';
+
+const useShowMoreContent = (
+  contentRef: RefObject<HTMLDivElement | HTMLParagraphElement>,
+  content: string
+) => {
+  const [isShowMore, setIsShowMore] = useState(false);
+  const [isContentOpen, setIsContentOpen] = useState(false);
+
+  useEffect(() => {
+    const contentTarget = contentRef.current;
+
+    if (contentTarget) {
+      setIsShowMore(contentTarget.clientHeight < contentTarget.scrollHeight);
+    }
+  }, [contentRef, content]);
+
+  const onOpenContent = () => {
+    setIsContentOpen(true);
+  };
+
+  const onCloseContent: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+
+    setIsContentOpen(false);
+  };
+
+  return { isShowMore, isContentOpen, onOpenContent, onCloseContent };
+};
+
+export default useShowMoreContent;

--- a/frontend/src/hooks/useShowMoreContent.ts
+++ b/frontend/src/hooks/useShowMoreContent.ts
@@ -1,9 +1,6 @@
 import { useEffect, useState, RefObject, MouseEventHandler } from 'react';
 
-const useShowMoreContent = (
-  contentRef: RefObject<HTMLDivElement | HTMLParagraphElement>,
-  content: string
-) => {
+const useShowMoreContent = (contentRef: RefObject<HTMLParagraphElement>, content: string) => {
   const [isShowMore, setIsShowMore] = useState(false);
   const [isContentOpen, setIsContentOpen] = useState(false);
 

--- a/frontend/src/mocks/drinksDetail.ts
+++ b/frontend/src/mocks/drinksDetail.ts
@@ -12,7 +12,7 @@ const drinksDetail = {
       id: 0,
       name: '맥주',
     },
-    description: '기네스',
+    description: '꽤 씁쓸하면서도 달콤 쌉싸름한 맛을 가지고 있다.',
     alcoholByVolume: 3.4,
     preferenceRate: 3.5,
     preferenceAvg: 2.5,

--- a/frontend/src/pages/DrinksDetailPage/index.tsx
+++ b/frontend/src/pages/DrinksDetailPage/index.tsx
@@ -4,16 +4,29 @@ import { useHistory, useParams } from 'react-router-dom';
 
 import UserContext from 'src/contexts/UserContext';
 import API from 'src/apis/requests';
+import useNoticeToInputPreference from 'src/hooks/useInputPreference';
+import useShowMoreContent from 'src/hooks/useShowMoreContent';
+
+import { properties } from './propertyData';
+
 import GoBackButton from 'src/components/@shared/GoBackButton/GoBackButton';
 import RangeWithIcons from 'src/components/RangeWithIcons/RangeWithIcons';
 import Review from 'src/components/Review/Review';
 import Property from 'src/components/Property/Property';
-import { properties } from './propertyData';
-import { Section, PreferenceSection, Image, DescriptionSection, Container } from './styles';
-import { COLOR, ERROR_MESSAGE, MESSAGE, PATH, PREFERENCE } from 'src/constants';
 import Skeleton from 'src/components/@shared/Skeleton/Skeleton';
 import DrinksDetailDescriptionSkeleton from 'src/components/Skeleton/DrinksDetailDescriptionSkeleton';
-import useNoticeToInputPreference from 'src/hooks/useInputPreference';
+
+import {
+  Section,
+  PreferenceSection,
+  Image,
+  DescriptionSection,
+  Container,
+  Description,
+  ShowMoreButton,
+  FoldButton,
+} from './styles';
+import { COLOR, ERROR_MESSAGE, MESSAGE, PATH, PREFERENCE } from 'src/constants';
 
 const defaultDrinkDetail = {
   name: 'name',
@@ -24,6 +37,7 @@ const defaultDrinkDetail = {
     name: '',
     key: '',
   },
+  description: '',
   alcoholByVolume: 0,
   preferenceRate: 0.0,
   preferenceAvg: 0.0,
@@ -36,6 +50,7 @@ const DrinksDetailPage = () => {
 
   const pageContainerRef = useRef<HTMLImageElement>(null);
   const preferenceRef = useRef<HTMLDivElement>(null);
+  const descriptionRef = useRef<HTMLParagraphElement>(null);
 
   const [currentPreferenceRate, setCurrentPreferenceRate] = useState(
     defaultDrinkDetail.preferenceRate
@@ -65,7 +80,13 @@ const DrinksDetailPage = () => {
     category: { key: categoryKey },
     alcoholByVolume,
     preferenceAvg,
+    description,
   }: Drink.DetailItem = drink;
+
+  const { isShowMore, isContentOpen, onOpenContent, onCloseContent } = useShowMoreContent(
+    descriptionRef,
+    description
+  );
 
   const { mutate: updatePreference } = useMutation(
     () => {
@@ -120,6 +141,16 @@ const DrinksDetailPage = () => {
     observePreferenceSection();
   };
 
+  const showButton = () => {
+    return isContentOpen ? (
+      <FoldButton type="button" onClick={onCloseContent}>
+        접기
+      </FoldButton>
+    ) : (
+      <ShowMoreButton type="button">...더보기</ShowMoreButton>
+    );
+  };
+
   return (
     <Container ref={pageContainerRef}>
       <GoBackButton color={COLOR.BLACK_900} />
@@ -171,6 +202,15 @@ const DrinksDetailPage = () => {
               );
             })}
           </ul>
+
+          <Description
+            isShowMore={isShowMore}
+            isContentOpen={isContentOpen}
+            onClick={onOpenContent}
+          >
+            <p ref={descriptionRef}>{description}</p>
+            {isShowMore && showButton()}
+          </Description>
         </DescriptionSection>
 
         <Review

--- a/frontend/src/pages/DrinksDetailPage/index.tsx
+++ b/frontend/src/pages/DrinksDetailPage/index.tsx
@@ -25,6 +25,7 @@ import {
   Description,
   ShowMoreButton,
   FoldButton,
+  ImageWrapper,
 } from './styles';
 import { COLOR, ERROR_MESSAGE, MESSAGE, PATH, PREFERENCE } from 'src/constants';
 
@@ -55,6 +56,7 @@ const DrinksDetailPage = () => {
   const [currentPreferenceRate, setCurrentPreferenceRate] = useState(
     defaultDrinkDetail.preferenceRate
   );
+  const [isShowImageFull, setIsShowImageFull] = useState(false);
 
   const isLoggedIn = useContext(UserContext)?.isLoggedIn;
 
@@ -151,15 +153,34 @@ const DrinksDetailPage = () => {
     );
   };
 
+  const onImageSizeIncrease = () => {
+    setIsShowImageFull(true);
+  };
+
+  const onImageSizeReduce = () => {
+    setIsShowImageFull(false);
+  };
+
   return (
     <Container ref={pageContainerRef}>
       <GoBackButton color={COLOR.BLACK_900} />
       {isLoading ? (
         <Skeleton width="100" height="30rem" />
       ) : (
-        <Image src={imageResponse.medium} alt={name} loading="lazy" />
+        <ImageWrapper>
+          <Image
+            src={imageResponse.medium}
+            alt={name}
+            loading="lazy"
+            onMouseDown={onImageSizeIncrease}
+            onMouseUp={onImageSizeReduce}
+            onTouchStart={onImageSizeIncrease}
+            onTouchEnd={onImageSizeReduce}
+          />
+        </ImageWrapper>
       )}
-      <Section>
+
+      <Section isShowImageFull={isShowImageFull}>
         <PreferenceSection ref={preferenceRef} isBlinked={isBlinked}>
           <h3>
             {currentPreferenceRate

--- a/frontend/src/pages/DrinksDetailPage/styles.ts
+++ b/frontend/src/pages/DrinksDetailPage/styles.ts
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 import { css, keyframes } from '@emotion/react';
+
+import LineClamp from 'src/styles/LineClamp';
 import { COLOR } from 'src/constants';
 
 const blinkEffect = keyframes`
@@ -29,8 +31,9 @@ const Section = styled.section`
 `;
 
 const PreferenceSection = styled.section<{ isBlinked: boolean }>`
-  margin-bottom: 3rem;
-  padding: 1rem 0;
+  margin-bottom: 1rem;
+  padding: 1rem 0 1.5rem;
+  border-bottom: 0.5px solid ${COLOR.GRAY_300};
 
   h3 {
     margin-bottom: 0.8rem;
@@ -56,6 +59,7 @@ const PreferenceSection = styled.section<{ isBlinked: boolean }>`
 
 const DescriptionSection = styled.section`
   margin-bottom: 3rem;
+  padding-top: 1rem;
 
   h2 {
     margin-bottom: 0.5rem;
@@ -65,7 +69,7 @@ const DescriptionSection = styled.section`
   }
 
   > p {
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
     line-height: 1.25;
   }
 
@@ -77,4 +81,72 @@ const DescriptionSection = styled.section`
   }
 `;
 
-export { Container, Section, PreferenceSection, Image, DescriptionSection };
+const Description = styled.div<{ isShowMore: boolean; isContentOpen: boolean }>`
+  margin: 2rem 0;
+  position: relative;
+
+  p {
+    ${({ isShowMore }) =>
+      isShowMore &&
+      css`
+        min-height: 3.8rem;
+      `}
+
+    ${({ isContentOpen }) => !isContentOpen && LineClamp({ lineClamp: 3 })}
+
+    width: 100%;
+    word-break: keep-all;
+    word-wrap: break-word;
+
+    line-height: 1.25;
+    color: ${COLOR.WHITE_200}dd;
+  }
+`;
+
+const descriptionButtonStyle = css`
+  position: absolute;
+  right: 0;
+  border: none;
+  height: 1.25rem;
+
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: ${COLOR.PURPLE_100};
+
+  background-color: ${COLOR.PURPLE_900};
+
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const FoldButton = styled.button`
+  ${descriptionButtonStyle};
+  height: 2rem;
+  bottom: -2rem;
+`;
+
+const ShowMoreButton = styled.button`
+  ${descriptionButtonStyle};
+
+  right: 0;
+  bottom: 0;
+  padding-left: 2rem;
+  background: linear-gradient(
+    90deg,
+    rgba(22, 14, 39) 0%,
+    rgba(0, 0, 0, 0) 0%,
+    rgba(22, 14, 39) 15%
+  );
+`;
+
+export {
+  Container,
+  Section,
+  PreferenceSection,
+  Image,
+  DescriptionSection,
+  Description,
+  ShowMoreButton,
+  FoldButton,
+};

--- a/frontend/src/pages/DrinksDetailPage/styles.ts
+++ b/frontend/src/pages/DrinksDetailPage/styles.ts
@@ -14,20 +14,26 @@ const Container = styled.div`
   position: relative;
 `;
 
-const Image = styled.img`
-  width: 100%;
-  height: fit-content;
+const ImageWrapper = styled.div`
+  padding: 3rem 0;
   background-color: ${COLOR.WHITE_100};
 `;
 
-const Section = styled.section`
+const Image = styled.img`
+  width: 100%;
+  height: fit-content;
+`;
+
+const Section = styled.section<{ isShowImageFull: boolean }>`
+  position: relative;
   border-top-left-radius: 24px;
   border-top-right-radius: 24px;
   background-color: ${COLOR.PURPLE_900};
-  transform: translateY(-6rem);
+  transform: ${({ isShowImageFull }) =>
+    isShowImageFull ? 'translateY(-2rem)' : 'translateY(-6rem)'};
   padding: 2rem 1.5rem;
+
   text-align: center;
-  position: relative;
 `;
 
 const PreferenceSection = styled.section<{ isBlinked: boolean }>`
@@ -142,9 +148,10 @@ const ShowMoreButton = styled.button`
 
 export {
   Container,
+  ImageWrapper,
+  Image,
   Section,
   PreferenceSection,
-  Image,
   DescriptionSection,
   Description,
   ShowMoreButton,

--- a/frontend/src/pages/DrinksDetailPage/test.tsx
+++ b/frontend/src/pages/DrinksDetailPage/test.tsx
@@ -55,6 +55,7 @@ describe('로그인 된 사용자가 상세페이지를 이용한다.', () => {
     expect(
       screen.getByText(`다른 사람들은 평균적으로 ${drinksDetail.data.preferenceAvg}점을 줬어요`)
     ).toBeVisible();
+    expect(screen.getByText(drinksDetail.data.description)).toBeVisible();
   });
 
   it('로그인 된 사용자는 상세페이지에서 선호도를 남길 수 있다.', async () => {


### PR DESCRIPTION
## resolve #372 

### 설명
- [x] 상세페이지에 주류 설명 추가
  - 주류 설명이 3줄 이상일 경우, 더보기 버튼 보이게 구현
  - 더보기 버튼을 눌렀을 때, 접을 수 있는 접기 버튼 구현
- [x] 상세페이지 이미지 영역 선택시, 이미지 전체가 보이게 구현
- [x] 상세페이지 테스트 코드 상세 설명 부분 추가

### 기타
- 리뷰의 더보기와 비슷하게 기능을 뺄 수 있을 것 같아서 hook으로 분리했는데, https://github.com/woowacourse-teams/2021-jujeol-jujeol/commit/79ea0ba6d229f5190c6516a51ef6fe19024d5e69 부분도 한번 봐주세용!
- 기존의 input에만 가지고 있던 작은 폰(320px)의 기본 폰트 사이즈를 모든 요소에 적용하게 하게 GlobalStyle 수정하였습니다. https://github.com/woowacourse-teams/2021-jujeol-jujeol/commit/97dd4ffd0a5fc0e8395a56bd36f06380e4e5a35d

### 이미지
<img width="30%" src="https://user-images.githubusercontent.com/59258239/134764664-ded92664-2e8c-42ee-95c8-fda01d2c5fd2.gif" alt="상세설명 추가한 시연영상">