### PR TITLE
hotfix: 리뷰 수정버튼이 snackbar에 가려 안눌리는 버그 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.jujeol.'
-version = '1.2.3-beta'
+version = '1.2.4-beta'
 sourceCompatibility = '11'
 
 configurations {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jujeol-jujeol-frontend",
-  "version": "1.2.3-beta",
+  "version": "1.2.4-beta",
   "description": "jujeol-jujeol-frontend",
   "main": "index.js",
   "scripts": {

--- a/frontend/src/GlobalStyle.tsx
+++ b/frontend/src/GlobalStyle.tsx
@@ -1,5 +1,5 @@
 import { Global, css } from '@emotion/react';
-import { COLOR } from './constants';
+import { COLOR, Z_INDEX } from './constants';
 
 const GlobalStyle = () => (
   <Global
@@ -43,15 +43,16 @@ const GlobalStyle = () => (
       }
 
       #snackbar {
-        position: absolute;
-        bottom: 10%;
-        left: 50%;
-        transform: translateX(-50%);
-
         width: 100%;
         max-width: 480px;
         min-width: 280px;
-        z-index: 15;
+
+        visibility: hidden;
+        position: fixed;
+        bottom: 10%;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: ${Z_INDEX.SNACKBAR};
       }
 
       html,

--- a/frontend/src/components/@shared/Snackbar/Snackbar.styles.ts
+++ b/frontend/src/components/@shared/Snackbar/Snackbar.styles.ts
@@ -13,30 +13,30 @@ const fadeInOut = keyframes`
 `;
 
 const Container = styled.section<{ message: boolean }>`
+  width: 90%;
+  padding: 1rem;
+  margin: 0 auto;
+
   ${Flex({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
   })}
-  width: 90%;
-  padding: 1rem;
-  margin: 0 auto;
 
   background-color: ${COLOR.PURPLE_500}CC;
-  color: ${COLOR.WHITE_200};
+
   font-size: 0.9rem;
   text-align: center;
   line-height: 1.5;
+  color: ${COLOR.WHITE_200};
 
   border-radius: 0.5rem;
-  visibility: hidden;
-
-  z-index: ${Z_INDEX.SNACKBAR};
 
   ${({ message }) =>
     message &&
     css`
       visibility: visible;
+
       animation: ${fadeInOut} 3s ease-out;
     `}
 


### PR DESCRIPTION
## resolve #376 

### 설명
snackbar poral 속성에 `visibility: hidden;` 을 추가하여, snackbar가 필요할 때 visible 상태가 되도록 수정하였습니다.

### 기타
* snackbar의 위치와 기존에 안눌리는 현상 gif
  <img width="30%" alt="스크린샷 2021-10-04 오후 12 29 09" src="https://user-images.githubusercontent.com/59258239/135789079-3c259d4d-e66e-4417-8b82-fda0f5eeee1c.png">
  <img width="30%" alt="스크린샷 2021-10-04 오후 12 29 09" src="https://user-images.githubusercontent.com/59258239/135789213-684b2b88-b718-4b7d-8285-e7b57fa14ed6.gif">

* 수정후
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/59258239/135789376-592a7843-05dc-4d4b-9282-961916693a3d.gif)


