### PR TITLE
feat: 퍼포먼스 측정 기능 추가

### DIFF
--- a/backend/src/main/java/com/jujeol/performance/PerformanceLogger.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceLogger.java
@@ -1,0 +1,78 @@
+package com.jujeol.performance;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Proxy;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class PerformanceLogger {
+
+    private static final Logger log = LoggerFactory.getLogger("performance-logger");
+
+    private final ObjectMapper objectMapper;
+    private ThreadLocal<PerformanceLoggingForm> logForm;
+
+    @Before("@within(org.springframework.transaction.annotation.Transactional) || @annotation(org.springframework.transaction.annotation.Transactional)")
+    public void beforeTransaction() {
+        final long startTransactionTime = System.currentTimeMillis();
+        try {
+            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
+                .currentRequestAttributes()).getRequest();
+            getLoggingForm().setTargetApi(request.getRequestURI());
+        } catch (IllegalStateException e) {
+            getLoggingForm().setTargetApi("dataLoader");
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+
+            @Override
+            public void afterCompletion(int status) {
+                try {
+                    getLoggingForm()
+                        .setTransactionTime(System.currentTimeMillis() - startTransactionTime);
+
+                    log.info(objectMapper.writeValueAsString(getLoggingForm()));
+                } catch (JsonProcessingException ignored) {
+                } finally {
+                    logForm.remove();
+                }
+            }
+        });
+
+    }
+
+    @Around("execution(* javax.sql.DataSource.getConnection())")
+    public Object datasource(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        final Object proceed = proceedingJoinPoint.proceed();
+        return Proxy.newProxyInstance(
+            proceed.getClass().getClassLoader(),
+            proceed.getClass().getInterfaces(),
+            new ProxyConnectionHandler(proceed, getLoggingForm()));
+    }
+
+    private PerformanceLoggingForm getLoggingForm() {
+        if (logForm == null) {
+            logForm = new ThreadLocal<>();
+        }
+
+        if (logForm.get() == null) {
+            logForm.set(new PerformanceLoggingForm());
+        }
+        return logForm.get();
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/PerformanceLogger.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceLogger.java
@@ -23,7 +23,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @RequiredArgsConstructor
 public class PerformanceLogger {
 
-    private static final Logger log = LoggerFactory.getLogger("performance-logger");
+    private static final Logger log = LoggerFactory.getLogger("PERFORMANCE");
 
     private final ObjectMapper objectMapper;
     private ThreadLocal<PerformanceLoggingForm> logForm;

--- a/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
@@ -1,0 +1,22 @@
+package com.jujeol.performance;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class PerformanceLoggingForm {
+
+    private String targetApi;
+    private Long transactionTime;
+    private Long queryCounts = 0L;
+    private Long queryTime = 0L;
+
+    public void queryCountUp() {
+        queryCounts++;
+    }
+
+    public void addQueryTime(Long queryTime) {
+        this.queryTime += queryTime;
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/ProxyConnectionHandler.java
+++ b/backend/src/main/java/com/jujeol/performance/ProxyConnectionHandler.java
@@ -1,0 +1,28 @@
+package com.jujeol.performance;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+public class ProxyConnectionHandler implements InvocationHandler {
+
+    private final Object connection;
+    private final PerformanceLoggingForm loggingForm;
+
+    public ProxyConnectionHandler(Object connection, PerformanceLoggingForm loggingForm) {
+        this.connection = connection;
+        this.loggingForm = loggingForm;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        final Object returnValue = method.invoke(connection, args);
+        if (method.getName().equals("prepareStatement")) {
+            return Proxy.newProxyInstance(
+                returnValue.getClass().getClassLoader(),
+                returnValue.getClass().getInterfaces(),
+                new ProxyPreparedStatementHandler(returnValue, loggingForm));
+        }
+        return returnValue;
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/ProxyPreparedStatementHandler.java
+++ b/backend/src/main/java/com/jujeol/performance/ProxyPreparedStatementHandler.java
@@ -1,0 +1,28 @@
+package com.jujeol.performance;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+public class ProxyPreparedStatementHandler implements InvocationHandler {
+
+    private final Object preparedStatement;
+    private final PerformanceLoggingForm loggingForm;
+
+    public ProxyPreparedStatementHandler(Object preparedStatement,
+                                         PerformanceLoggingForm loggingForm) {
+        this.preparedStatement = preparedStatement;
+        this.loggingForm = loggingForm;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if(method.getName().equals("executeQuery")) {
+            final long startTime = System.currentTimeMillis();
+            final Object returnValue = method.invoke(preparedStatement, args);
+            loggingForm.addQueryTime(System.currentTimeMillis() - startTime);
+            loggingForm.queryCountUp();
+            return returnValue;
+        }
+        return method.invoke(preparedStatement, args);
+    }
+}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -38,6 +38,19 @@
       <maxHistory>3</maxHistory>
       </rollingPolicy>
     </appender>
+    <appender name="PERFORMANCE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${LOG_PATH}/performance.log</file>
+      <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+        <pattern>${LOG_FILE_PATTERN}</pattern>
+      </encoder>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_PATH}/performance.%d{yyyy-MM-dd}_%i.zip</fileNamePattern>
+        <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+          <maxFileSize>100MB</maxFileSize>
+        </timeBasedFileNamingAndTriggeringPolicy>
+        <maxHistory>3</maxHistory>
+      </rollingPolicy>
+    </appender>
     <appender name="FILE-async" class="ch.qos.logback.classic.AsyncAppender">
       <appender-ref ref="FILE" />
       <queueSize>256</queueSize>
@@ -46,7 +59,17 @@
       <neverBlock>true</neverBlock>
       <maxFlushTime>3000</maxFlushTime>
     </appender>
+    <appender name="PERFORMANCE-async" class="ch.qos.logback.classic.AsyncAppender">
+      <appender-ref ref="PERFORMANCE" />
+      <queueSize>256</queueSize>
+      <discardingThreshold>20</discardingThreshold>
+      <includeCallerData>false</includeCallerData>
+      <neverBlock>true</neverBlock>
+      <maxFlushTime>3000</maxFlushTime>
+    </appender>
   </springProfile>
+
+
 
   <root level="INFO">
     <springProfile name="console-logging">
@@ -54,6 +77,7 @@
     </springProfile>
     <springProfile name="file-logging">
       <appender-ref ref="FILE-async"/>
+      <appender-ref ref="PERFORMANCE-async"/>
     </springProfile>
   </root>
 </configuration>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
       <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
       <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-        <pattern>${LOG_FILE_PATTERN}</pattern>
+        <pattern>%msg%n</pattern>
       </encoder>
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
         <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.zip</fileNamePattern>


### PR DESCRIPTION
## related #381

### 설명
- 퍼포먼스 측정 로그 추가
- 각 api 당 트랜잭션 시간, 쿼리 개수, 쿼리 수행시간 추가
- 예시
```
14:30:36.270 [http-nio-8080-exec-1] [INFO ] [PERFORMANCE] - {"targetApi":"/drinks","transactionTime":46,"queryCounts":13,"queryTime":7}
```

### 기타
이 로그를 바탕으로 cloudwatch log table 에 트랜잭션 시간 순 api 를 보여주며 평균 수치를 보여줄 예정입니다!
