### PR TITLE
refactor: 퍼포먼스 측정에 api 형식과 method 형식 추가

### DIFF
--- a/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 public class PerformanceLoggingForm {
 
     private String targetApi;
+    private String targetMethod;
     private Long transactionTime;
     private Long queryCounts = 0L;
     private Long queryTime = 0L;

--- a/backend/src/main/java/com/jujeol/performance/RequestApi.java
+++ b/backend/src/main/java/com/jujeol/performance/RequestApi.java
@@ -1,0 +1,14 @@
+package com.jujeol.performance;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestApi {
+
+    private String urlForm;
+    private String method;
+}

--- a/backend/src/main/java/com/jujeol/performance/RequestApiExtractor.java
+++ b/backend/src/main/java/com/jujeol/performance/RequestApiExtractor.java
@@ -1,0 +1,52 @@
+package com.jujeol.performance;
+
+import com.jujeol.performance.annotationDataExtractor.AnnotationDataExtractor;
+import com.jujeol.performance.annotationDataExtractor.GetMappingDataExtractor;
+import com.jujeol.performance.annotationDataExtractor.PostMappingDataExtractor;
+import com.jujeol.performance.annotationDataExtractor.PutMappingDataExtractor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Component
+public class RequestApiExtractor {
+
+    private final List<AnnotationDataExtractor> dataExtractors = new ArrayList<>();
+
+    RequestApiExtractor() {
+        dataExtractors.add(new GetMappingDataExtractor());
+        dataExtractors.add(new PostMappingDataExtractor());
+        dataExtractors.add(new PutMappingDataExtractor());
+    }
+
+    public RequestApi extractRequestApi(JoinPoint joinPoint) {
+        final String classUrl = getClassUrl(joinPoint);
+        final MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+
+        final Optional<AnnotationDataExtractor> extractor = dataExtractors.stream()
+                .filter(annotationDataExtractor -> annotationDataExtractor
+                        .isAssignable(methodSignature.getMethod()))
+                .findAny();
+
+        if (extractor.isEmpty()) {
+            return new RequestApi();
+        }
+        return extractor.get().extractRequestApi(methodSignature.getMethod(), classUrl);
+    }
+
+    private String getClassUrl(JoinPoint joinPoint) {
+        final Class<?> targetClass = joinPoint.getTarget().getClass();
+        if (targetClass.isAnnotationPresent(RequestMapping.class)) {
+            final RequestMapping requestMapping = targetClass.getAnnotation(RequestMapping.class);
+            return Arrays.stream(requestMapping.value())
+                    .findAny()
+                    .orElseGet(() -> Arrays.stream(requestMapping.path()).findAny().orElse(""));
+        }
+        return "";
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/RequestApiExtractor.java
+++ b/backend/src/main/java/com/jujeol/performance/RequestApiExtractor.java
@@ -1,6 +1,7 @@
 package com.jujeol.performance;
 
 import com.jujeol.performance.annotationDataExtractor.AnnotationDataExtractor;
+import com.jujeol.performance.annotationDataExtractor.DeleteMappingDataExtractor;
 import com.jujeol.performance.annotationDataExtractor.GetMappingDataExtractor;
 import com.jujeol.performance.annotationDataExtractor.PostMappingDataExtractor;
 import com.jujeol.performance.annotationDataExtractor.PutMappingDataExtractor;
@@ -22,6 +23,7 @@ public class RequestApiExtractor {
         dataExtractors.add(new GetMappingDataExtractor());
         dataExtractors.add(new PostMappingDataExtractor());
         dataExtractors.add(new PutMappingDataExtractor());
+        dataExtractors.add(new DeleteMappingDataExtractor());
     }
 
     public RequestApi extractRequestApi(JoinPoint joinPoint) {

--- a/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/AnnotationDataExtractor.java
+++ b/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/AnnotationDataExtractor.java
@@ -1,0 +1,11 @@
+package com.jujeol.performance.annotationDataExtractor;
+
+import com.jujeol.performance.RequestApi;
+import java.lang.reflect.Method;
+
+public interface AnnotationDataExtractor {
+
+    boolean isAssignable(Method method);
+
+    RequestApi extractRequestApi(Method method, String classUrl);
+}

--- a/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/DeleteMappingDataExtractor.java
+++ b/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/DeleteMappingDataExtractor.java
@@ -1,0 +1,27 @@
+package com.jujeol.performance.annotationDataExtractor;
+
+import com.jujeol.performance.RequestApi;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+
+public class DeleteMappingDataExtractor implements AnnotationDataExtractor {
+
+    @Override
+    public boolean isAssignable(Method method) {
+        return method.isAnnotationPresent(DeleteMapping.class);
+    }
+
+    @Override
+    public RequestApi extractRequestApi(Method method, String classUrl) {
+        final DeleteMapping deleteMapping = method.getAnnotation(DeleteMapping.class);
+        final String api = Arrays.stream(deleteMapping.value())
+                .findAny()
+                .orElseGet(() ->
+                        Arrays.stream(deleteMapping.path()).findAny()
+                                .orElse("")
+                );
+        return new RequestApi(classUrl + api, "DELETE");
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/GetMappingDataExtractor.java
+++ b/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/GetMappingDataExtractor.java
@@ -1,0 +1,25 @@
+package com.jujeol.performance.annotationDataExtractor;
+
+import com.jujeol.performance.RequestApi;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import org.springframework.web.bind.annotation.GetMapping;
+
+public class GetMappingDataExtractor implements AnnotationDataExtractor {
+
+    @Override
+    public boolean isAssignable(Method method) {
+        return method.isAnnotationPresent(GetMapping.class);
+    }
+
+    @Override
+    public RequestApi extractRequestApi(Method method, String classUrl) {
+        final GetMapping getMapping = method.getAnnotation(GetMapping.class);
+        final String api = Arrays.stream(getMapping.value())
+                .findAny()
+                .orElseGet(() ->
+                        Arrays.stream(getMapping.path()).findAny().orElse("")
+                );
+        return new RequestApi(classUrl + api, "GET");
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/PostMappingDataExtractor.java
+++ b/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/PostMappingDataExtractor.java
@@ -1,0 +1,25 @@
+package com.jujeol.performance.annotationDataExtractor;
+
+import com.jujeol.performance.RequestApi;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import org.springframework.web.bind.annotation.PostMapping;
+
+public class PostMappingDataExtractor implements AnnotationDataExtractor {
+
+    @Override
+    public boolean isAssignable(Method method) {
+        return method.isAnnotationPresent(PostMapping.class);
+    }
+
+    @Override
+    public RequestApi extractRequestApi(Method method, String classUrl) {
+        final PostMapping postMapping = method.getAnnotation(PostMapping.class);
+        final String api = Arrays.stream(postMapping.value())
+                .findAny()
+                .orElseGet(() ->
+                        Arrays.stream(postMapping.path()).findAny().orElse("")
+                );
+        return new RequestApi(classUrl + api, "POST");
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/PutMappingDataExtractor.java
+++ b/backend/src/main/java/com/jujeol/performance/annotationDataExtractor/PutMappingDataExtractor.java
@@ -1,0 +1,26 @@
+package com.jujeol.performance.annotationDataExtractor;
+
+import com.jujeol.performance.RequestApi;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import org.springframework.web.bind.annotation.PutMapping;
+
+public class PutMappingDataExtractor implements AnnotationDataExtractor {
+
+    @Override
+    public boolean isAssignable(Method method) {
+        return method.isAnnotationPresent(PutMapping.class);
+    }
+
+    @Override
+    public RequestApi extractRequestApi(Method method, String classUrl) {
+        final PutMapping putMapping = method.getAnnotation(PutMapping.class);
+        final String api = Arrays.stream(putMapping.value())
+                .findAny()
+                .orElseGet(() ->
+                        Arrays.stream(putMapping.path()).findAny()
+                                .orElse("")
+                );
+        return new RequestApi(classUrl + api, "PUT");
+    }
+}


### PR DESCRIPTION
## resolve #406  

### 설명
- 퍼포먼스 측정에 api 형식과 method 형식 추가
- 원래는 HttpRequest 에서 api 형식을 가져와서 drinks/1, drinks/2 이렇게 받아오게 되었습니다! 각각이 다른 api 주소가 아닌 drinks/{id} 로 받아오고 싶어 HttpRequest 에서 가져오는 것이 아닌 @RequestMapping 혹은 @GetMapping 과 같은 어노테이션 정보를 이용해 api 를 가져올 수 있도록 수정했습니다!
- 해당 로그로 최종적으로 cloudWatch 에서 각각의 api + method 의 평균 트랜잭션 시간, 쿼리 시간, 쿼리 수 를 모니터링하게 만들 예정입니다!

### 최종 로그 폼
```
16:18:24.149 [http-nio-8080-exec-2] [INFO ] [PERFORMANCE] - {"targetApi":"/drinks","targetMethod":"GET","transactionTime":42,"queryCounts":13,"queryTime":4}

```