### PR TITLE
feat: 관리자페이지 이미지가 없을 시 업데이트가 안 되는 오류 수정

### DIFF
--- a/admin/src/js/drinks/view/drinkTable.js
+++ b/admin/src/js/drinks/view/drinkTable.js
@@ -71,13 +71,13 @@ function renderDrinkPaginationButton (currentPage, lastPage) {
   const $drinkPagination = $("#drinkPagination");
   $drinkPagination.innerHTML = '';
   currentPage = Number(currentPage);
-
+  
   const offset = 5;
   const previousNumber = currentPage - offset > 0 ? currentPage - offset : 1;
   const nextNumber = currentPage + offset < lastPage ? currentPage + offset : lastPage;
 
-  const start = (currentPage - 2) > 1 ? (currentPage - 2) : 1;
-  const last = (currentPage + 2) < lastPage ? (currentPage + 2) : lastPage;
+  const start = (currentPage - offset) > 1 ? (currentPage - offset) : 1;
+  const last = (currentPage + offset) < lastPage ? (currentPage + offset) : lastPage;
 
   $drinkPagination.insertAdjacentHTML('beforeend', pageItem("previous", previousNumber))
   for ( let i = start; i <= last; i++ ) {

--- a/backend/src/main/java/com/jujeol/admin/ui/AdminController.java
+++ b/backend/src/main/java/com/jujeol/admin/ui/AdminController.java
@@ -11,6 +11,7 @@ import com.jujeol.drink.drink.application.dto.ImageFilePathDto;
 import com.jujeol.member.auth.ui.AuthenticationPrincipal;
 import com.jujeol.member.auth.ui.LoginMember;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +24,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,28 +38,38 @@ public class AdminController {
 
     @GetMapping("/drinks")
     public CommonResponse<List<AdminDrinkResponse>> showDrinks(
-            @PageableDefault(value = 20, sort = "id", direction = Direction.DESC) Pageable pageable,
-            @AuthenticationPrincipal LoginMember loginMember) {
-        final Page<AdminDrinkResponse> drinks = drinkService.showAllDrinksByPage(pageable, loginMember)
-                .map(AdminDrinkResponse::from);
+        @PageableDefault(value = 20, sort = "id", direction = Direction.DESC) Pageable pageable,
+        @AuthenticationPrincipal LoginMember loginMember) {
+        final Page<AdminDrinkResponse> drinks = drinkService
+            .showAllDrinksByPage(pageable, loginMember)
+            .map(AdminDrinkResponse::from);
         return PageResponseAssembler.assemble(drinks);
     }
 
     @PostMapping("/drinks")
-    public CommonResponse<?> insertDrinks(@ModelAttribute AdminDrinkRequest adminDrinkRequest) {
-        ImageFilePathDto imageFilePathDto = imageService.insert(adminDrinkRequest.getImage());
+    public CommonResponse<?> insertDrinks(
+        @ModelAttribute AdminDrinkRequest adminDrinkRequest,
+        @RequestPart MultipartFile image
+    ) {
+        ImageFilePathDto imageFilePathDto = imageService.insert(image);
         drinkService.insertDrink(adminDrinkRequest.toDto(
-                imageFilePathDto
+            imageFilePathDto
         ));
         return CommonResponse.ok();
     }
 
     @PutMapping("/drinks/{id}")
     public CommonResponse<?> updateDrink(@PathVariable Long id,
-            @ModelAttribute AdminDrinkRequest adminDrinkRequest) {
+        @ModelAttribute AdminDrinkRequest adminDrinkRequest,
+        @RequestPart(required = false) MultipartFile image
+    ) {
         DrinkDto drinkDto = drinkService.showDrinkDetail(id);
-        ImageFilePathDto existingImage = drinkDto.getImageFilePathDto();
-        ImageFilePathDto imageFilePathDto = imageService.update(existingImage, adminDrinkRequest.getImage());
+        ImageFilePathDto imageFilePathDto = drinkDto.getImageFilePathDto();
+
+        if (Objects.nonNull(image)) {
+            imageFilePathDto = imageService.update(imageFilePathDto, image);
+        }
+
         drinkService.updateDrink(id, adminDrinkRequest.toDto(
             imageFilePathDto
         ));

--- a/backend/src/main/java/com/jujeol/admin/ui/dto/AdminDrinkRequest.java
+++ b/backend/src/main/java/com/jujeol/admin/ui/dto/AdminDrinkRequest.java
@@ -17,7 +17,6 @@ public class AdminDrinkRequest {
     private String name;
     private String englishName;
     private Double alcoholByVolume;
-    private MultipartFile image;
     private String categoryKey;
     private String description;
 

--- a/backend/src/test/java/com/jujeol/admin/acceptance/AdminAcceptanceTest.java
+++ b/backend/src/test/java/com/jujeol/admin/acceptance/AdminAcceptanceTest.java
@@ -63,14 +63,15 @@ class AdminAcceptanceTest extends AcceptanceTest {
         adminAcceptanceTool.어드민_주류_데이터_등록(KGB, STELLA);
         final Long stellaId = drinkAcceptanceTool.주류_아이디_조회(STELLA.getName());
 
+        MockMultipartFile mockImage = new MockMultipartFile("test.jpeg",
+            "test.png",
+            "image/jpeg",
+            Files.readAllBytes(TEST_IMAGE.toPath()));
+
         final AdminDrinkRequest newStella =
             new AdminDrinkRequest("스텔라2",
                 "stella2",
                 2.0,
-                new MockMultipartFile("test.jpeg",
-                    "test.png",
-                    "image/jpeg",
-                    Files.readAllBytes(TEST_IMAGE.toPath())),
                 "BEER",
                 "상세 설명을 수정 중입니다."
             );
@@ -84,7 +85,7 @@ class AdminAcceptanceTest extends AcceptanceTest {
                 .addMultipart("categoryKey", newStella.getCategoryKey())
                 .addMultipart("description", newStella.getDescription())
                 .addMultipart("alcoholByVolume", newStella.getAlcoholByVolume())
-                .addMultipart("image", newStella.getImage())
+                .addMultipart("image", mockImage)
                 .build();
 
         //then

--- a/backend/src/test/java/com/jujeol/admin/acceptance/AdminAcceptanceTool.java
+++ b/backend/src/test/java/com/jujeol/admin/acceptance/AdminAcceptanceTool.java
@@ -1,5 +1,7 @@
 package com.jujeol.admin.acceptance;
 
+import static com.jujeol.drink.acceptance.DrinkAcceptanceTool.TEST_MULTIPART;
+
 import com.jujeol.RequestBuilder;
 import com.jujeol.RequestBuilder.HttpResponse;
 import com.jujeol.admin.ui.dto.AdminDrinkRequest;
@@ -18,8 +20,6 @@ import org.springframework.test.context.ActiveProfiles;
 @Component
 @ActiveProfiles("test")
 public class AdminAcceptanceTool {
-
-    public static final File THUMBNAIL_IMAGE = new File(new File("").getAbsolutePath() + "/src/test/resources/static/test.png");
 
     @Autowired
     private RequestBuilder requestBuilder;
@@ -40,7 +40,7 @@ public class AdminAcceptanceTool {
                     .addMultipart("categoryKey", adminDrinkRequest.getCategoryKey())
                     .addMultipart("description", adminDrinkRequest.getDescription())
                     .addMultipart("alcoholByVolume", adminDrinkRequest.getAlcoholByVolume())
-                    .addMultipart("image", adminDrinkRequest.getImage())
+                    .addMultipart("image", TEST_MULTIPART)
                     .build()
                     .convertBody(AdminDrinkResponse.class)
             );
@@ -48,8 +48,4 @@ public class AdminAcceptanceTool {
         return adminDrinkResponses;
     }
 
-    private MultiPartSpecification setUtf8Charset(String data, String columnName){
-        return new MultiPartSpecBuilder(data)
-            .controlName(columnName).charset(Charsets.UTF_8).build();
-    }
 }

--- a/backend/src/test/java/com/jujeol/drink/DrinkTestContainer.java
+++ b/backend/src/test/java/com/jujeol/drink/DrinkTestContainer.java
@@ -1,41 +1,39 @@
 package com.jujeol.drink;
 
-import static com.jujeol.drink.acceptance.DrinkAcceptanceTool.TEST_MULTIPART;
-
 import com.jujeol.admin.ui.dto.AdminDrinkRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public enum DrinkTestContainer {
-    OB(new AdminDrinkRequest("오비", "OB", 8.5, TEST_MULTIPART, "BEER",
-            "맥주의 청량감이 느껴지는 맥주이다.")),
+    OB(new AdminDrinkRequest("오비", "OB", 8.5, "BEER",
+        "맥주의 청량감이 느껴지는 맥주이다.")),
     TIGER_LEMON(new AdminDrinkRequest("타이거 라들러 레몬", "Tiger_Lemon", 4.5,
-        TEST_MULTIPART, "BEER", "레몬맛이 느껴지는 맥주이다.")),
+        "BEER", "레몬맛이 느껴지는 맥주이다.")),
     STELLA(new AdminDrinkRequest("스텔라", "stella", 5.5,
-        TEST_MULTIPART, "BEER", "스텔라만의 맛이 느껴지는 맥주이다.")),
-    KGB(new AdminDrinkRequest("KGB", "", 3.5, TEST_MULTIPART, "BEER",
-            "KGB는 맥주가 아니다.")),
-    ESTP(new AdminDrinkRequest("ESTP", "", 7.5, TEST_MULTIPART,
-            "BEER", "ESTP 맛이 나는 맥주이다.")),
+        "BEER", "스텔라만의 맛이 느껴지는 맥주이다.")),
+    KGB(new AdminDrinkRequest("KGB", "", 3.5, "BEER",
+        "KGB는 맥주가 아니다.")),
+    ESTP(new AdminDrinkRequest("ESTP", "", 7.5,
+        "BEER", "ESTP 맛이 나는 맥주이다.")),
     TIGER_RAD(new AdminDrinkRequest("타이거 라들러 자몽", "Tiger_Rad", 9.5,
-        TEST_MULTIPART, "BEER", "라드 맛이 나는 맥주이다.")),
+        "BEER", "라드 맛이 나는 맥주이다.")),
     TSINGTAO(new AdminDrinkRequest("칭따오", "TSINGTAO", 12.0,
-        TEST_MULTIPART, "BEER", "양꼬치와 잘어울리는 맥주이다.")),
-    APPLE(new AdminDrinkRequest("애플", "Apple", 8.2, TEST_MULTIPART,
-            "BEER", "사과맛이 나는 맥주이다.")),
+        "BEER", "양꼬치와 잘어울리는 맥주이다.")),
+    APPLE(new AdminDrinkRequest("애플", "Apple", 8.2,
+        "BEER", "사과맛이 나는 맥주이다.")),
     WINE(new AdminDrinkRequest("와인", "Wine", 8.2,
-        TEST_MULTIPART, "WINE", "테스트1 상세설명")),
+        "WINE", "테스트1 상세설명")),
     TEST_TWO(new AdminDrinkRequest("테스트2", "Test2", 8.2,
-        TEST_MULTIPART, "BEER", "테스트2 상세설명")),
+        "BEER", "테스트2 상세설명")),
     TEST_THREE(new AdminDrinkRequest("테스트3", "Test3", 8.2,
-        TEST_MULTIPART, "BEER", "테스트3 상세설명")),
+        "BEER", "테스트3 상세설명")),
     TEST_FOUR(new AdminDrinkRequest("테스트4", "Test4", 8.2,
-        TEST_MULTIPART, "BEER", "테스트4 상세설명")),
+        "BEER", "테스트4 상세설명")),
     TEST_FIVE(new AdminDrinkRequest("테스트5", "Test5", 8.2,
-        TEST_MULTIPART, "BEER", "테스트5 상세설명")),
+        "BEER", "테스트5 상세설명")),
     TEST_SIX(new AdminDrinkRequest("테스트6", "Test6", 8.2,
-        TEST_MULTIPART, "BEER", "테스트6 상세설명")),
+        "BEER", "테스트6 상세설명")),
     ;
 
     private final AdminDrinkRequest adminDrinkRequest;
@@ -45,14 +43,14 @@ public enum DrinkTestContainer {
     }
 
     public static List<AdminDrinkRequest> asAdminRequestList(
-            DrinkTestContainer... drinkTestContainer) {
+        DrinkTestContainer... drinkTestContainer) {
         return Arrays.stream(drinkTestContainer).map(DrinkTestContainer::getAdminDrinkRequest)
-                .collect(Collectors.toList());
+            .collect(Collectors.toList());
     }
 
     public static List<String> asNames(DrinkTestContainer... drinkTestContainers) {
         return Arrays.stream(drinkTestContainers).map(DrinkTestContainer::getName)
-                .collect(Collectors.toList());
+            .collect(Collectors.toList());
     }
 
     public AdminDrinkRequest getAdminDrinkRequest() {


### PR DESCRIPTION
## resolve #395 

### 설명
- 관리자 페이지에서 수정 시, 이미지를 업로드 하지 않아도 다른 칼럼의 정보를 수정할 수 있도록 함

### 기타
