### PR TITLE
chore: 릴리즈 노트 자동생성을 위한 github action 설정

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,23 @@
+name-template: "v$NEXT_MINOR_VERSION 🌈"
+tag-template: "v$NEXT_MINOR_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "🕹 기능"
+      - "⚒ 리팩토링"
+      - "📱유아이"
+      - "🖥 어드민"
+      - "🏗 인프라"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "🐞 버그"
+      - "🚐 핫픽스"
+  - title: "❌ Deprecated"
+    labels:
+      - "❌ 사용되지않음"
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -8,6 +8,8 @@ categories:
       - "📱유아이"
       - "🖥 어드민"
       - "🏗 인프라"
+      - "🌈 프론트"
+      - "🔥 백엔드"
   - title: "🐛 Bug Fixes"
     labels:
       - "🐞 버그"
@@ -17,9 +19,7 @@ categories:
       - "❌ 사용되지않음"
 exclude-labels:
   - "⚙️ 설정"
-  - "🌈 프론트"
   - "🍻 테스트"
-  - "🔥 백엔드"
   - "📋 문서"
   - "🚨 이슈"
 change-template: "- $TITLE (#$NUMBER)"

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -15,6 +15,13 @@ categories:
   - title: "❌ Deprecated"
     labels:
       - "❌ 사용되지않음"
+exclude-labels:
+  - "⚙️ 설정"
+  - "🌈 프론트"
+  - "🍻 테스트"
+  - "🔥 백엔드"
+  - "📋 문서"
+  - "🚨 이슈"
 change-template: "- $TITLE (#$NUMBER)"
 change-title-escapes: '\<*_&'
 template: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           config-name: release-drafter-config.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}


### PR DESCRIPTION
## resolve #243 

### 설명
자세한 설정은 [🖇 문서](https://github.com/marketplace/actions/release-drafter)를 참고해주세요
메이저 버전 업만 자동생성 되며, 핫픽스의 경우에는 따로 release 노트를 생성해야 합니다.
릴리즈 노트가 다음과 같이 생성됩니다.

참고하지 않을 라벨 목록
 `⚙️ 설정`, `🌈 프론트`, `🍻 테스트`, `🔥 백엔드`, `📋 문서`, `🚨 이슈`

👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇

## Changes


## 🚀 Features
- `🕹 기능` 라벨을 사용한 PR closed 되었을 때
-  `⚒ 리팩토링` 라벨을 사용한 PR closed 되었을 때
- `📱유아이` 라벨을 사용한 PR closed 되었을 때
- `🖥 어드민` 라벨을 사용한 PR closed 되었을 때
-  `🏗 인프라` 라벨을 사용한 PR closed 되었을 때
- ex) refactor: button 삭제 (#10)

## 🐛 Bug Fixes

- `🐞 버그` 라벨을 사용한 PR closed 되었을 때
-  `🚐 핫픽스` 라벨을 사용한 PR closed 되었을 때

## ❌ Deprecated

- `❌ 사용되지않음` 라벨을 사용한 PR closed 되었을 때

