### PR TITLE
feat: 토큰 유효기간 연장 및 토큰 유효기간 예외 추가

### DIFF
--- a/backend/src/main/java/com/jujeol/commons/exception/ExceptionCodeAndDetails.java
+++ b/backend/src/main/java/com/jujeol/commons/exception/ExceptionCodeAndDetails.java
@@ -12,6 +12,7 @@ import com.jujeol.drink.drink.exception.NotFoundDrinkException;
 import com.jujeol.drink.drink.exception.NotFoundViewCountException;
 import com.jujeol.member.auth.exception.InvalidTokenException;
 import com.jujeol.member.auth.exception.KakaoAccessException;
+import com.jujeol.member.auth.exception.TokenExpiredException;
 import com.jujeol.member.auth.exception.UnauthorizedUserException;
 import com.jujeol.member.member.exception.InvalidUserBiographyLengthException;
 import com.jujeol.member.member.exception.InvalidUserNicknameCharacterException;
@@ -43,6 +44,7 @@ public enum ExceptionCodeAndDetails {
         InvalidUserNicknameCharacterException.class),
     INVALID_USER_BIOGRAPHY_LENGTH("1008", "자기 소개가 너무 깁니다.",
         InvalidUserBiographyLengthException.class),
+    EXPIRED_TOKEN("1009", "토큰 유효기간이 만료되었습니다.", TokenExpiredException.class),
 
     INVALID_ALCOHOL_BY_VOLUME("2001", "해당 주류의 도수가 잘 못 되었습니다.",
         InvalidAlcoholByVolumeException.class),

--- a/backend/src/main/java/com/jujeol/member/auth/exception/TokenExpiredException.java
+++ b/backend/src/main/java/com/jujeol/member/auth/exception/TokenExpiredException.java
@@ -1,0 +1,7 @@
+package com.jujeol.member.auth.exception;
+
+import com.jujeol.commons.exception.JujeolException;
+
+public class TokenExpiredException extends JujeolException {
+
+}

--- a/backend/src/main/java/com/jujeol/member/auth/infrastructure/kakao/KakaoClient.java
+++ b/backend/src/main/java/com/jujeol/member/auth/infrastructure/kakao/KakaoClient.java
@@ -34,14 +34,17 @@ public class KakaoClient implements SocialClient {
 
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(AUTHORIZATION, String.format(BEARER_FORM, accessToken));
-        final String body = restTemplate
-                .exchange(kakaoOauthInfo.getKakaoUserUrl(), HttpMethod.GET,
-                        new HttpEntity<>(httpHeaders),
-                        String.class)
-                .getBody();
-
-        final String id = clientResponseConverter.extractDataAsString(body, ID);
-        return new KakaoMemberDetails(id);
+        try {
+            final String body = restTemplate
+                    .exchange(kakaoOauthInfo.getKakaoUserUrl(), HttpMethod.GET,
+                            new HttpEntity<>(httpHeaders),
+                            String.class)
+                    .getBody();
+            final String id = clientResponseConverter.extractDataAsString(body, ID);
+            return new KakaoMemberDetails(id);
+        } catch (HttpClientErrorException e) {
+            throw new KakaoAccessException();
+        }
     }
 
     @Override

--- a/backend/src/main/java/com/jujeol/member/auth/util/JwtTokenProvider.java
+++ b/backend/src/main/java/com/jujeol/member/auth/util/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.jujeol.member.auth.util;
 
+import com.jujeol.member.auth.exception.TokenExpiredException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
@@ -38,7 +39,11 @@ public class JwtTokenProvider {
         try {
             Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
 
-            return !claims.getBody().getExpiration().before(new Date());
+            if(claims.getBody().getExpiration().before(new Date())) {
+               throw new TokenExpiredException();
+            }
+
+            return true;
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }


### PR DESCRIPTION
### 설명
- 토큰 유효기간이 연장됩니다.
- 토큰 유효기간이 만료되면 예외코드 1009번, 토큰 유효기간이 만료되었습니다. 의 메시지와 함께 예외를 던집니다.
- jujeol-auth 서브모듈 바라보는 커밋이 달라집니다.