### PR TITLE
feat:  noscript 태그 추가 및 SEO 개선을 위한 meta 태그 설정

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,6 +5,8 @@
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="맛있는 술을 더 즐겁게, 술 추천 서비스 주절주절 입니다." />
+
   <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
 
   <meta property="og:type" content="website">
@@ -39,6 +41,7 @@
 </head>
 
 <body>
+  <noscript>현재 사용 중인 브라우저는 스크립트를 지원하지 않거나, 해당 기능이 활성화되어 있지 않습니다. 스크립트를 활성화하거나 다른 브라우저를 사용해주세요.</noscript>
   <div id="background-aria">
     <div class="dialog">
       <p>무슨 술 마시지? 🧐</p>
@@ -62,6 +65,7 @@
       </svg>
     </div>
   </div>
+
   <div id="root"></div>
   <div id="modal"></div>
   <div id="confirm"></div>


### PR DESCRIPTION
## resolve #449 

### 설명
- SEO 개선을 위한 meta 태그의 `name=description` 속성 추가
- 스크립트를 지원하지 않은 브라우저를 위한 noscript 태그 추가

### 기타
- [meta tag의 이름(name)](https://developer.mozilla.org/ko/docs/Web/HTML/Element/meta/name)에 대한 설명
  - `name description`의 meta 태그는 검색했을 때 페이지에 대한 간략한 설명을 보여준다.
- [noscript에 대한 설명 ](https://developer.mozilla.org/ko/docs/Web/HTML/Element/noscript)
  - `noscript`는 브라우저가 페이지의 스크립트 유형을 지원하지 않거나, 비활성화 했을 때 보여진다.
