### PR TITLE
fix: svg 가로, 세로 단위 px로 변경 및 아이콘 크기 조정

### DIFF
--- a/frontend/src/components/@Icons/AllIcon.tsx
+++ b/frontend/src/components/@Icons/AllIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const AllIcon = ({ width = '2rem', height = '2rem', color = COLOR.BLACK }: IconProps) => {
+const AllIcon = ({ width = '32px', height = '32px', color = COLOR.BLACK }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/ArrowIcon.tsx
+++ b/frontend/src/components/@Icons/ArrowIcon.tsx
@@ -12,8 +12,8 @@ interface Props extends IconProps {
 }
 
 const ArrowIcon = ({
-  width = '2rem',
-  height = '2rem',
+  width = '32px',
+  height = '32px',
   color = COLOR.BLACK,
   direction = 'LEFT',
 }: Props) => {

--- a/frontend/src/components/@Icons/BeerColorIcon.tsx
+++ b/frontend/src/components/@Icons/BeerColorIcon.tsx
@@ -1,4 +1,4 @@
-const BeerColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const BeerColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/BeerIcon.tsx
+++ b/frontend/src/components/@Icons/BeerIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const BeerIcon = ({ width = '2rem', height = '2rem', color = COLOR.BLACK }: IconProps) => {
+const BeerIcon = ({ width = '32px', height = '32px', color = COLOR.BLACK }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/CancelIcon.tsx
+++ b/frontend/src/components/@Icons/CancelIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const CancelIcon = ({ width = '2rem', height = '2rem', color = COLOR.BLACK }: IconProps) => {
+const CancelIcon = ({ width = '32px', height = '32px', color = COLOR.BLACK }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/CategoryEtcColorIcon.tsx
+++ b/frontend/src/components/@Icons/CategoryEtcColorIcon.tsx
@@ -1,4 +1,4 @@
-const CategoryEtcColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const CategoryEtcColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/CategoryEtcIcon.tsx
+++ b/frontend/src/components/@Icons/CategoryEtcIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const CategoryEtcIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const CategoryEtcIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/CocktailColorIcon.tsx
+++ b/frontend/src/components/@Icons/CocktailColorIcon.tsx
@@ -1,4 +1,4 @@
-const CocktailColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const CocktailColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/CocktailIcon.tsx
+++ b/frontend/src/components/@Icons/CocktailIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const CocktailIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const CocktailIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/DizzyEmojiColorIcon.tsx
+++ b/frontend/src/components/@Icons/DizzyEmojiColorIcon.tsx
@@ -1,4 +1,4 @@
-const DizzyEmojiColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const DizzyEmojiColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/DizzyEmojiIcon.tsx
+++ b/frontend/src/components/@Icons/DizzyEmojiIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const DizzyEmojiIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const DizzyEmojiIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/EditIcon.tsx
+++ b/frontend/src/components/@Icons/EditIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const EditIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const EditIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/ExcitedEmojiColorIcon.tsx
+++ b/frontend/src/components/@Icons/ExcitedEmojiColorIcon.tsx
@@ -1,4 +1,4 @@
-const ExcitedEmojiColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const ExcitedEmojiColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/ExcitedEmojiIcon.tsx
+++ b/frontend/src/components/@Icons/ExcitedEmojiIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const ExcitedEmojiIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const ExcitedEmojiIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/HomeIcon.tsx
+++ b/frontend/src/components/@Icons/HomeIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const HomeIcon = ({ width = '2rem', height = '2rem', color = COLOR.BLACK }: IconProps) => {
+const HomeIcon = ({ width = '32px', height = '32px', color = COLOR.BLACK }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/HumanIcon.tsx
+++ b/frontend/src/components/@Icons/HumanIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const HumanIcon = ({ width = '2rem', height = '2rem', color = COLOR.BLACK }: IconProps) => {
+const HumanIcon = ({ width = '32px', height = '32px', color = COLOR.BLACK }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/LoginIcon.tsx
+++ b/frontend/src/components/@Icons/LoginIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const LoginIcon = ({ width = '2rem', height = '2rem', color = COLOR.BLACK }: IconProps) => {
+const LoginIcon = ({ width = '32px', height = '32px', color = COLOR.BLACK }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/LoveEmojiColorIcon.tsx
+++ b/frontend/src/components/@Icons/LoveEmojiColorIcon.tsx
@@ -1,4 +1,4 @@
-const LoveEmojiColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const LoveEmojiColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/LoveEmojiIcon.tsx
+++ b/frontend/src/components/@Icons/LoveEmojiIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const LoveEmojiIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const LoveEmojiIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/MakgeolliColorIcon.tsx
+++ b/frontend/src/components/@Icons/MakgeolliColorIcon.tsx
@@ -1,4 +1,4 @@
-const MakgeolliColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const MakgeolliColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/MakgeolliIcon.tsx
+++ b/frontend/src/components/@Icons/MakgeolliIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const MakgeolliIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const MakgeolliIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/MeatBallsIcon.tsx
+++ b/frontend/src/components/@Icons/MeatBallsIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const MeatBallsIcon = ({ width = '2rem', height = '2rem', color = COLOR.BLACK }: IconProps) => {
+const MeatBallsIcon = ({ width = '32px', height = '32px', color = COLOR.BLACK }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/SearchIcon.tsx
+++ b/frontend/src/components/@Icons/SearchIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const SearchIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const SearchIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/SearchIconForTab.tsx
+++ b/frontend/src/components/@Icons/SearchIconForTab.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const SearchIconForTab = ({ width = '2rem', height = '2rem', color = COLOR.BLACK }: IconProps) => {
+const SearchIconForTab = ({ width = '32px', height = '32px', color = COLOR.BLACK }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/SmileEmojiColorIcon.tsx
+++ b/frontend/src/components/@Icons/SmileEmojiColorIcon.tsx
@@ -1,4 +1,4 @@
-const SmileEmojiColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const SmileEmojiColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/SmileEmojiIcon.tsx
+++ b/frontend/src/components/@Icons/SmileEmojiIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const SmileEmojiIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const SmileEmojiIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/SojuColorIcon.tsx
+++ b/frontend/src/components/@Icons/SojuColorIcon.tsx
@@ -1,4 +1,4 @@
-const SojuColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const SojuColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/SojuIcon.tsx
+++ b/frontend/src/components/@Icons/SojuIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const SojuIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const SojuIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/StarIcon.tsx
+++ b/frontend/src/components/@Icons/StarIcon.tsx
@@ -12,7 +12,7 @@ interface Props extends IconProps {
   status?: fillStatus;
 }
 
-const StarIcon = ({ color = COLOR.WHITE, status = 'FULL', width = '3rem' }: Props) => {
+const StarIcon = ({ color = COLOR.YELLOW_300, status = 'FULL', width = '48px' }: Props) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/WineColorIcon.tsx
+++ b/frontend/src/components/@Icons/WineColorIcon.tsx
@@ -1,4 +1,4 @@
-const WineColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const WineColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/WineIcon.tsx
+++ b/frontend/src/components/@Icons/WineIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const WineIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const WineIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/YangjuColorIcon.tsx
+++ b/frontend/src/components/@Icons/YangjuColorIcon.tsx
@@ -1,4 +1,4 @@
-const YangjuColorIcon = ({ width = '2rem', height = '2rem' }: IconProps) => {
+const YangjuColorIcon = ({ width = '32px', height = '32px' }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/@Icons/YangjuIcon.tsx
+++ b/frontend/src/components/@Icons/YangjuIcon.tsx
@@ -1,6 +1,6 @@
 import { COLOR } from 'src/constants';
 
-const YangjuIcon = ({ width = '2rem', height = '2rem', color = COLOR.WHITE }: IconProps) => {
+const YangjuIcon = ({ width = '32px', height = '32px', color = COLOR.WHITE }: IconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/Card/ReviewCard.styles.ts
+++ b/frontend/src/components/Card/ReviewCard.styles.ts
@@ -7,6 +7,10 @@ const Header = styled.div`
   margin-bottom: 0.5rem;
 
   ${Flex({})}
+
+  button {
+    padding: 0.3rem;
+  }
 `;
 
 const ReviewerInfo = styled.div`

--- a/frontend/src/components/Profile/Profile.styles.ts
+++ b/frontend/src/components/Profile/Profile.styles.ts
@@ -33,6 +33,8 @@ const Container = styled.section`
 `;
 
 const EditButtonStyle = css`
+  padding: 0.3rem;
+
   position: absolute;
   top: -15%;
   right: 0;

--- a/frontend/src/components/SearchBar/SearchBar.styles.ts
+++ b/frontend/src/components/SearchBar/SearchBar.styles.ts
@@ -14,6 +14,10 @@ const Container = styled.form<Omit<React.CSSProperties, 'translate'>>`
   background-color: rgba(255, 255, 255, 0.3);
   border: 2px solid white;
   border-radius: 2rem;
+
+  button {
+    padding: 0.3rem;
+  }
 `;
 
 const SearchInput = styled.input<Omit<React.CSSProperties, 'translate'>>`


### PR DESCRIPTION
## resolve #471 
### 설명
- 아이콘 컴포넌트 단위 2rem => 32px 로변경
- 아이콘 버튼 padding 직접 설정.

 ![image](https://user-images.githubusercontent.com/67677561/139018882-4d14e27e-3371-4217-8187-fca4e1277cb7.png)
### 기타
