### PR TITLE
fix: modal bottm padding을 모바일에 맞게 조정

### DIFF
--- a/frontend/src/components/Modal/Modal.styles.ts
+++ b/frontend/src/components/Modal/Modal.styles.ts
@@ -50,7 +50,7 @@ const Content = styled.div<{ isOpened: boolean; isTouchDown: boolean }>`
   height: 80vh;
   border-top-right-radius: 1.5rem;
   border-top-left-radius: 1.5rem;
-  padding: 2.5rem 2rem 2rem;
+  padding: 2.5rem 2rem 5rem;
   position: absolute;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
## resolve #474

### 설명
- 모바일 환경 bottom이 한참 아래인 관계로, 하단 패딩 높이를 높였습니다.
- 전
![image](https://user-images.githubusercontent.com/67677561/139022896-03d9979f-1102-41ce-9311-98ebcc707160.png)

- 후
![image](https://user-images.githubusercontent.com/67677561/139022928-2c3d9ae6-dfd4-46a6-9e8d-c000eca19dc0.png)

### 기타
