### PR TITLE
Fix: preference 페이지에서 전체 데이터가 불러와 지지 않는 이슈 해결

### DIFF
--- a/frontend/src/pages/PreferencePage/index.tsx
+++ b/frontend/src/pages/PreferencePage/index.tsx
@@ -33,7 +33,7 @@ const PreferencePage = () => {
     ({ pageParam = 1 }) =>
       API.getDrinks({
         page: pageParam,
-        params: new URLSearchParams('sortBy=preferenceAvg&size=10'),
+        params: new URLSearchParams('size=25'),
       }),
     {
       getNextPageParam: ({ pageInfo }) => {
@@ -95,6 +95,12 @@ const PreferencePage = () => {
     };
   }, [infinityPollRef.current]);
 
+  useEffect(() => {
+    if (!drinks.filter(({ preferenceRate }) => !preferenceRate).length && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [drinks]);
+
   return (
     <>
       <NavigationHeader title="선호도 평가" />
@@ -127,17 +133,12 @@ const PreferencePage = () => {
                 <Skeleton type="SQUARE" size="X_SMALL" width="100%" />
               </FlexBox>
             ))}
-          {!drinks.filter(({ preferenceRate }) => !preferenceRate).length && (
+          {!drinks.filter(({ preferenceRate }) => !preferenceRate).length && !hasNextPage && (
             <NoDrink>
               <DizzyEmojiColorIcon />
               <p>주절주절에 있는 모든 술을 드셨네요!</p>
               <p>회원님을 이 구역의 술쟁이로 인정합니다!</p>
             </NoDrink>
-          )}
-          {!!drinks.filter(({ preferenceRate }) => !preferenceRate).length && !hasNextPage && (
-            <Notification>
-              <p>등록된 술이 더이상 없습니다. 곧 추가 될 예정이니 기다려 주세요 :)</p>
-            </Notification>
           )}
         </div>
         <InfinityScrollPoll ref={infinityPollRef} />

--- a/frontend/src/pages/PreferencePage/index.tsx
+++ b/frontend/src/pages/PreferencePage/index.tsx
@@ -48,6 +48,7 @@ const PreferencePage = () => {
     }
   );
   const drinks = data?.pages?.map((page) => page.data).flat() ?? [];
+  const hasUnratedDrinks = !!drinks.filter(({ preferenceRate }) => !preferenceRate).length;
 
   const observer = new IntersectionObserver((entries) => {
     entries.forEach((entry) => {
@@ -96,10 +97,10 @@ const PreferencePage = () => {
   }, [infinityPollRef.current]);
 
   useEffect(() => {
-    if (!drinks.filter(({ preferenceRate }) => !preferenceRate).length && hasNextPage) {
+    if (!hasUnratedDrinks && hasNextPage) {
       fetchNextPage();
     }
-  }, [drinks]);
+  }, [hasUnratedDrinks]);
 
   return (
     <>
@@ -133,12 +134,17 @@ const PreferencePage = () => {
                 <Skeleton type="SQUARE" size="X_SMALL" width="100%" />
               </FlexBox>
             ))}
-          {!drinks.filter(({ preferenceRate }) => !preferenceRate).length && !hasNextPage && (
+          {!hasUnratedDrinks && !hasNextPage && (
             <NoDrink>
               <DizzyEmojiColorIcon />
               <p>주절주절에 있는 모든 술을 드셨네요!</p>
               <p>회원님을 이 구역의 술쟁이로 인정합니다!</p>
             </NoDrink>
+          )}
+          {hasUnratedDrinks && !hasNextPage && (
+            <Notification>
+              <p>등록된 술이 더이상 없습니다. 곧 추가 될 예정이니 기다려 주세요 :)</p>
+            </Notification>
           )}
         </div>
         <InfinityScrollPoll ref={infinityPollRef} />


### PR DESCRIPTION
## resolve #473

### 설명
- 한 번에 불러오는 데이터의 수 증가 (10개 > 25개)
- 불러온 데이터를 필터링 한 결과 값이 없고, 다음페이지가 있으면, fetchNextPage 시도하기
<img width="408" alt="스크린샷 2021-10-27 오후 7 50 25" src="https://user-images.githubusercontent.com/67677561/139052787-94363569-f918-48d0-9584-ad273ab37c0c.png">

### 기타
