### PR TITLE
fix: 상대경로 문제로 인한 css 파일 미적용 해결

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -23,9 +23,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&display=swap"
     rel="stylesheet">
-  <link rel="preload" href="./index.css" as="style" />
+  <link rel="preload" href="%PUBLIC_URL%/index.css" as="style" />
 
-  <link rel="stylesheet" href="./index.css" />
+  <link rel="stylesheet" href="%PUBLIC_URL%/index.css" />
+
 
   <!-- Global site tag (gtag.js) - Google Analytics only for prod -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8EM73DMKBC"></script>
@@ -33,7 +34,6 @@
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-
     gtag('config', 'G-8EM73DMKBC');
   </script>
 

--- a/frontend/src/pages/ErrorPage/styles.ts
+++ b/frontend/src/pages/ErrorPage/styles.ts
@@ -32,7 +32,10 @@ export const LinkButton = styled(Link)`
 
   background-color: ${COLOR.YELLOW_300};
   border-radius: 1rem;
-  color: ${COLOR.BLACK};
+
+  && {
+    color: ${COLOR.BLACK};
+  }
 
   text-align: center;
 `;


### PR DESCRIPTION
## resolve #479 

### 설명
- url depth가 2이상인 페이지에서 index.css파일을 './index.css'와 같이 상대경로로 표현했을 때, 불러오지 못하는 이슈 해결
```html
 <link rel="preload" href="%PUBLIC_URL%/index.css" as="style" />
 <link rel="stylesheet" href="%PUBLIC_URL%/index.css" />
```
