### PR TITLE
fix: 선호도 평가 페이지 api 요청이 성공할 때에만 데이터 마지막 안내 문구 표시

### DIFF
--- a/frontend/src/pages/PreferencePage/index.tsx
+++ b/frontend/src/pages/PreferencePage/index.tsx
@@ -28,7 +28,7 @@ const PreferencePage = () => {
 
   const queryClient = useQueryClient();
 
-  const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery(
+  const { data, fetchNextPage, hasNextPage, isFetching, isSuccess } = useInfiniteQuery(
     QUERY_KEY.DRINK_LIST_SORTED_BY_PREFERENCE,
     ({ pageParam = 1 }) =>
       API.getDrinks({
@@ -144,14 +144,14 @@ const PreferencePage = () => {
                 <Skeleton type="SQUARE" size="X_SMALL" width="100%" />
               </FlexBox>
             ))}
-          {!hasUnratedDrinks && !hasNextPage && (
+          {isSuccess && !hasUnratedDrinks && !hasNextPage && (
             <NoDrink>
               <DizzyEmojiColorIcon />
               <p>주절주절에 있는 모든 술을 드셨네요!</p>
               <p>회원님을 이 구역의 술쟁이로 인정합니다!</p>
             </NoDrink>
           )}
-          {hasUnratedDrinks && !hasNextPage && (
+          {isSuccess && hasUnratedDrinks && !hasNextPage && (
             <Notification>
               <p>등록된 술이 더이상 없습니다. 곧 추가 될 예정이니 기다려 주세요 :)</p>
             </Notification>


### PR DESCRIPTION
## resolve #496 
### 설명
* infinityQuery의 상태가 isSuccess일 때에만, 모든 술 평가 완료 / 술 목록 마지막 문구 표시

* 전
![image](https://user-images.githubusercontent.com/67677561/139097576-147194ff-6233-4163-bfc8-05d32663ce5a.png)
* 후
![image](https://user-images.githubusercontent.com/67677561/139097646-f45eee91-7818-4ec1-b7e8-3fd918308325.png)

### 기타
