### PR TITLE
fix: 검색결과에 페이지네이션이 안되는 오류 해결

### DIFF
--- a/frontend/src/pages/DrinksListPage/index.tsx
+++ b/frontend/src/pages/DrinksListPage/index.tsx
@@ -9,6 +9,7 @@ import ListItem from 'src/components/Item/ListItem';
 import List from 'src/components/List/List';
 import ListItemSkeleton from 'src/components/Skeleton/ListItemSkeleton';
 import { APPLICATION_ERROR_CODE, ERROR_MESSAGE, PATH } from 'src/constants';
+import useInfinityScroll from 'src/hooks/useInfinityScroll';
 import usePageTitle from 'src/hooks/usePageTitle';
 import { Container, InfinityScrollPoll } from './styles';
 
@@ -65,23 +66,11 @@ const DrinksListPage = () => {
   const drinks = data?.pages?.map((page) => page.data).flat() ?? [];
   const totalSize = data?.pages[0].pageInfo?.totalSize;
 
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting && hasNextPage) {
-        fetchNextPage();
-      }
-    });
-  });
-
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
-  useEffect(() => {
-    if (infinityPollRef.current) {
-      observer.observe(infinityPollRef.current);
-    }
-  }, [infinityPollRef.current]);
+  useInfinityScroll({ target: infinityPollRef, fetchNextPage, hasNextPage });
 
   return (
     <Container>

--- a/frontend/src/pages/PreferencePage/index.tsx
+++ b/frontend/src/pages/PreferencePage/index.tsx
@@ -13,6 +13,7 @@ import NavigationHeader from 'src/components/Header/NavigationHeader';
 import { APPLICATION_ERROR_CODE, ERROR_MESSAGE, PATH } from 'src/constants';
 import QUERY_KEY from 'src/constants/queryKey';
 import UserContext from 'src/contexts/UserContext';
+import useInfinityScroll from 'src/hooks/useInfinityScroll';
 import usePageTitle from 'src/hooks/usePageTitle';
 import MemoizedPreferenceItem from './PreferenceItem';
 import { AlertWrapper, Container, InfinityScrollPoll, NoDrink, Notification } from './styles';
@@ -60,13 +61,7 @@ const PreferencePage = () => {
   const drinks = data?.pages?.map((page) => page.data).flat() ?? [];
   const hasUnratedDrinks = !!drinks.filter(({ preferenceRate }) => !preferenceRate).length;
 
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting && hasNextPage) {
-        fetchNextPage();
-      }
-    });
-  });
+  useInfinityScroll({ target: infinityPollRef, fetchNextPage, hasNextPage });
 
   const { mutate: onUpdatePreference } = useMutation(
     ({ id, preferenceRate }: { id: number; preferenceRate: number }) => {
@@ -93,24 +88,6 @@ const PreferencePage = () => {
   const onMoveToDrinkDetail = (id: number) => () => {
     history.push(`${PATH.DRINKS}/${id}`);
   };
-
-  useEffect(() => {
-    if (infinityPollRef.current) {
-      observer.observe(infinityPollRef.current);
-    }
-
-    return () => {
-      if (infinityPollRef.current) {
-        observer.unobserve(infinityPollRef.current);
-      }
-    };
-  }, [infinityPollRef.current]);
-
-  useEffect(() => {
-    if (!hasUnratedDrinks && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [hasUnratedDrinks]);
 
   return (
     <>

--- a/frontend/src/pages/SearchResultPage/index.tsx
+++ b/frontend/src/pages/SearchResultPage/index.tsx
@@ -83,7 +83,17 @@ const SearchResultPage = () => {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+
   useInfinityScroll({ target: observerTargetRef, fetchNextPage, hasNextPage });
+
+  const getSkeletonUI = () => (
+    <>
+      <Skeleton type="TEXT" size="MEDIUM" width="14rem" margin="1rem 2rem" />
+      <List>
+        <ListItemSkeleton count={7} />
+      </List>
+    </>
+  );
 
   return (
     <Container>
@@ -91,12 +101,7 @@ const SearchResultPage = () => {
 
       <section>
         {isLoading ? (
-          <>
-            <Skeleton type="TEXT" size="MEDIUM" width="14rem" margin="1rem 2rem" />
-            <List>
-              <ListItemSkeleton count={7} />
-            </List>
-          </>
+          getSkeletonUI()
         ) : searchResult?.length ? (
           <>
             <SearchResult>
@@ -119,11 +124,12 @@ const SearchResultPage = () => {
                 />
               ))}
             </List>
-            <InfinityScrollPoll ref={observerTargetRef} />
           </>
         ) : (
           <NoSearchResults search={words || categoryName || ''} />
         )}
+
+        <InfinityScrollPoll ref={observerTargetRef} />
       </section>
     </Container>
   );


### PR DESCRIPTION
## resolve #497 

### 설명
- 검색결과 페이지의 무한스크롤의 observe 대상이 데이터 fetching에 성공했을 때만 불러오게 설계가 되어 있어서, 검색결과를 가지고 오지 못하는 경우에도 옵저빙이 되도록 코드 수정
- DrinksListPage와 PreferencePage에 useInfinityScroll hook 적용

### 기타
