### PR TITLE
refactor: Tab component icon의 border 투명하게 변경

### DIFF
--- a/frontend/src/components/@Icons/StarIcon.tsx
+++ b/frontend/src/components/@Icons/StarIcon.tsx
@@ -12,12 +12,17 @@ interface Props extends IconProps {
   status?: fillStatus;
 }
 
-const StarIcon = ({ color = COLOR.YELLOW_300, status = 'FULL', width = '48px' }: Props) => {
+const StarIcon = ({
+  borderColor = COLOR.YELLOW_300,
+  color = COLOR.YELLOW_300,
+  status = 'FULL',
+  width = '48px',
+}: Props) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 31.58 30.52"
-      stroke={color}
+      stroke={borderColor}
       width={width}
       preserveAspectRatio="xMidYMid meet"
     >

--- a/frontend/src/components/Tab/Tab.tsx
+++ b/frontend/src/components/Tab/Tab.tsx
@@ -73,7 +73,7 @@ const Tab = () => {
         {tabConfig(isLoggedIn).map(({ mainPath, path, title, Icon }) => (
           <li key={title}>
             <NavLink exact to={mainPath} isActive={() => path.includes(location.pathname)}>
-              <Icon />
+              <Icon borderColor="transparent" />
               <p>{title}</p>
             </NavLink>
           </li>

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -73,6 +73,7 @@ declare namespace Review {
 }
 
 declare interface IconProps {
+  borderColor?: string;
   color?: string;
   width?: string;
   height?: string;


### PR DESCRIPTION
## resolve #503 

### 설명
- [x] icon Props에 선택 속성으로 borderColor를 추가한다.
- [x] starIcon에 선택 속성으로 borderColor를 transparent로 설정한다.