### PR TITLE
fix: 빈이 생성되지 않는 오류 해결

### DIFF
--- a/backend/src/main/java/com/jujeol/BeanLoader.java
+++ b/backend/src/main/java/com/jujeol/BeanLoader.java
@@ -1,0 +1,18 @@
+package com.jujeol;
+
+import com.jujeol.elasticsearch.domain.reopsitory.DrinkDocumentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BeanLoader implements CommandLineRunner {
+
+    private final DrinkDocumentRepository drinkDocumentRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+
+    }
+}


### PR DESCRIPTION
## resolve #507

### 설명
DrinkDocumentRepository가 빈 생성이 힘들어 ElasticConfig 에서 오류가 생김

### 해결 방법
DataLoader 를 이용해 빈을 먼저 생성해줌
