### PR TITLE
fix: 검색어가 공백으로 왔을 때 500 error 제어

### DIFF
--- a/backend/src/main/java/com/jujeol/elasticsearch/infrastructure/ElasticSearchHelper.java
+++ b/backend/src/main/java/com/jujeol/elasticsearch/infrastructure/ElasticSearchHelper.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.jujeol.drink.drink.domain.Drink;
 import com.jujeol.drink.drink.domain.repository.DrinkRepository;
+import com.jujeol.drink.drink.exception.NotFoundDrinkException;
 import com.jujeol.elasticsearch.application.SearchHelper;
 import com.jujeol.elasticsearch.domain.DrinkDocument;
 import com.jujeol.elasticsearch.domain.reopsitory.DrinkDocumentQueryBuilder;
@@ -34,6 +35,14 @@ public class ElasticSearchHelper implements SearchHelper {
 
         final SearchHits<DrinkDocument> searchHits = elasticsearchRestTemplate
                 .search(query, DrinkDocument.class, IndexCoordinates.of("drink"));
+        if (!searchHits.hasSearchHits()) {
+            return new DrinkSearchResult(
+                    new ArrayList<>(),
+                    pageable,
+                    searchHits.getTotalHits()
+            );
+        }
+
         final SearchPage<DrinkDocument> searchHitsByPage = SearchHitSupport
                 .searchPageFor(searchHits, query.getPageable());
 
@@ -55,7 +64,7 @@ public class ElasticSearchHelper implements SearchHelper {
                     drinks.stream()
                             .filter(drink -> id.equals(drink.getId()))
                             .findAny()
-                            .orElseThrow()
+                            .orElseThrow(NotFoundDrinkException::new)
             );
         }
         return sortedDrinks;


### PR DESCRIPTION
## resolve #478

검색어가 공백으로 왔을 때 빈 결과를 반환하도록 변경