### PR TITLE
fix: 주류 검색 시, 검색어나 카테고리에 빈문자열을 넣고 URL 검색을 했을 시 로직 수정

### DIFF
--- a/frontend/src/pages/DrinksListPage/index.tsx
+++ b/frontend/src/pages/DrinksListPage/index.tsx
@@ -35,7 +35,7 @@ const DrinksListPage = () => {
   const category =
     (new URLSearchParams(history.location.search).get('category') as keyof typeof CATEGORY_NAME) ??
     'ALL';
-  const categoryName = CATEGORY_NAME[category];
+  const categoryName = CATEGORY_NAME[category] ?? CATEGORY_NAME['ALL'];
   const params = new URLSearchParams({ category });
 
   const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery(

--- a/frontend/src/pages/SearchResultPage/index.tsx
+++ b/frontend/src/pages/SearchResultPage/index.tsx
@@ -14,7 +14,6 @@ import { ERROR_MESSAGE, PATH } from 'src/constants';
 import APPLICATION_ERROR_CODE from 'src/constants/applicationErrorCode';
 import useInfinityScroll from 'src/hooks/useInfinityScroll';
 import usePageTitle from 'src/hooks/usePageTitle';
-import { categories } from '../SearchPage';
 import NoSearchResults from './NoSearchResults';
 import { Container, SearchResult } from './styles';
 
@@ -25,19 +24,16 @@ const SearchResultPage = () => {
   const { setSnackbarMessage } = useContext(SnackbarContext) ?? {};
 
   const words = new URLSearchParams(location.search).get('words') ?? '';
-  const categoryKey = new URLSearchParams(location.search).get('category') ?? '';
-  const categoryName =
-    categoryKey && categories.find((category) => category.key === categoryKey)?.name;
+  const params = new URLSearchParams({ keyword: words });
 
-  const params = new URLSearchParams({ keyword: words, category: categoryKey });
-
-  params.forEach((value, key) => {
-    if (value === '') {
-      params.delete(key);
+  useEffect(() => {
+    if (words === '') {
+      history.push(PATH.SEARCH);
+      return;
     }
-  });
+  }, [words]);
 
-  usePageTitle(`${words || categoryName} 검색 결과`);
+  usePageTitle(`${words} 검색 결과`);
 
   const {
     data: resultsData,
@@ -105,7 +101,7 @@ const SearchResultPage = () => {
         ) : searchResult?.length ? (
           <>
             <SearchResult>
-              <strong>{words || categoryName}</strong>로 검색한 결과입니다.
+              <strong>{words}</strong>로 검색한 결과입니다.
             </SearchResult>
             <List count={searchResult?.length || 0}>
               {searchResult?.map((item: Drink.Item) => (
@@ -126,7 +122,7 @@ const SearchResultPage = () => {
             </List>
           </>
         ) : (
-          <NoSearchResults search={words || categoryName || ''} />
+          <NoSearchResults search={words || ''} />
         )}
 
         <InfinityScrollPoll ref={observerTargetRef} />


### PR DESCRIPTION
## resolve #522 

### 설명
- `http://localhost:3000/search/result?words=`를 입력하면, 검색 페이지로 redirect한다.
- `http://localhost:3000/drinks?category=`를 입력하면, 전체 주류를 보여준다.

### 기타
https://user-images.githubusercontent.com/59258239/139224838-41a7f798-396f-4e30-8f9d-bd304e766881.mov


