### PR TITLE
hotfix: 모바일 사파리에서 카카오톡 공유하기 버튼에 로고가 노충되지 않는 이슈 해결

### DIFF
--- a/frontend/src/components/ShareLinks/CopyLinkButton.styles.ts
+++ b/frontend/src/components/ShareLinks/CopyLinkButton.styles.ts
@@ -14,6 +14,10 @@ export const Container = styled.div<{ css: SerializedStyles }>`
     cursor: copy;
   }
 
+  svg {
+    height: 1rem;
+  }
+
   > input {
     // input이 화면에 보이지 않으면 select할 범위를 찾지 못하는 이슈로 인해, 화면 바깥으로 숨김
     position: fixed;


### PR DESCRIPTION
## resolve #549

### 설명
- 모바일 사파리에서 카카오톡 공유하기 버튼에 로고가 노충되지 않는 이슈 해결
- svg height 지정 이슈.

### 기타
