### PR TITLE
fix: 상세페이지에 들어갔다, 다른 페이지에 들어가면 이전 이미지가 눈에 보이고, 새로운 데이터가 보여지는 문제해결

### DIFF
--- a/frontend/src/pages/DrinksDetailPage/index.tsx
+++ b/frontend/src/pages/DrinksDetailPage/index.tsx
@@ -80,7 +80,7 @@ const DrinksDetailPage = () => {
   const { setConfirm, closeConfirm } = useContext(confirmContext) ?? {};
 
   const { data: { data: drink = defaultDrinkDetail } = {}, isLoading } = useQuery(
-    QUERY_KEY.DRINK_DETAIL,
+    [QUERY_KEY.DRINK_DETAIL, drinkId],
     () => API.getDrink<string>(drinkId),
     {
       retry: 0,


### PR DESCRIPTION
## resolve #571

### 설명
- 리액트 쿼리키를 각 아이템에 맞춰 설정

### 기타
