### PR TITLE
refactor: 퍼포먼스 측정을 트랜잭션 시간이 아니라 요청 응답 시간으로 변경

### DIFF
--- a/backend/src/main/java/com/jujeol/performance/LogFormDto.java
+++ b/backend/src/main/java/com/jujeol/performance/LogFormDto.java
@@ -1,40 +1,26 @@
 package com.jujeol.performance;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
 public class LogFormDto {
 
     private String targetApi;
     private String targetMethod;
-    private Long requestTime;
+    @JsonProperty("requestTime")
+    private Long requestTimeMils;
     private Long queryCounts;
-    private Long queryTime;
+    @JsonProperty("queryTime")
+    private Long queryTimeMils;
 
     public static LogFormDto from(PerformanceLoggingForm logForm) {
         final LogFormDto logFormDto = new LogFormDto();
         logFormDto.targetApi = logForm.getTargetApi();
         logFormDto.targetMethod = logForm.getTargetMethod();
-        logFormDto.requestTime = logForm.getRequestTime();
+        logFormDto.requestTimeMils = logForm.getRequestTime();
         logFormDto.queryCounts = logForm.getQueryCounts();
-        logFormDto.queryTime = logForm.getQueryTime();
+        logFormDto.queryTimeMils = logForm.getQueryTime();
         return logFormDto;
-    }
-
-    public String getTargetApi() {
-        return targetApi;
-    }
-
-    public String getTargetMethod() {
-        return targetMethod;
-    }
-
-    public Long getRequestTime() {
-        return requestTime;
-    }
-
-    public Long getQueryCounts() {
-        return queryCounts;
-    }
-
-    public Long getQueryTime() {
-        return queryTime;
     }
 }

--- a/backend/src/main/java/com/jujeol/performance/LogFormDto.java
+++ b/backend/src/main/java/com/jujeol/performance/LogFormDto.java
@@ -18,9 +18,9 @@ public class LogFormDto {
         final LogFormDto logFormDto = new LogFormDto();
         logFormDto.targetApi = logForm.getTargetApi();
         logFormDto.targetMethod = logForm.getTargetMethod();
-        logFormDto.requestTimeMils = logForm.getRequestTime();
+        logFormDto.requestTimeMils = logForm.getRequestTimeMils();
         logFormDto.queryCounts = logForm.getQueryCounts();
-        logFormDto.queryTimeMils = logForm.getQueryTime();
+        logFormDto.queryTimeMils = logForm.getQueryTimeMils();
         return logFormDto;
     }
 }

--- a/backend/src/main/java/com/jujeol/performance/LogFormDto.java
+++ b/backend/src/main/java/com/jujeol/performance/LogFormDto.java
@@ -4,7 +4,7 @@ public class LogFormDto {
 
     private String targetApi;
     private String targetMethod;
-    private Long transactionTime;
+    private Long requestTime;
     private Long queryCounts;
     private Long queryTime;
 
@@ -12,7 +12,7 @@ public class LogFormDto {
         final LogFormDto logFormDto = new LogFormDto();
         logFormDto.targetApi = logForm.getTargetApi();
         logFormDto.targetMethod = logForm.getTargetMethod();
-        logFormDto.transactionTime = logForm.getTransactionTime();
+        logFormDto.requestTime = logForm.getRequestTime();
         logFormDto.queryCounts = logForm.getQueryCounts();
         logFormDto.queryTime = logForm.getQueryTime();
         return logFormDto;
@@ -26,8 +26,8 @@ public class LogFormDto {
         return targetMethod;
     }
 
-    public Long getTransactionTime() {
-        return transactionTime;
+    public Long getRequestTime() {
+        return requestTime;
     }
 
     public Long getQueryCounts() {

--- a/backend/src/main/java/com/jujeol/performance/LogFormDto.java
+++ b/backend/src/main/java/com/jujeol/performance/LogFormDto.java
@@ -1,0 +1,40 @@
+package com.jujeol.performance;
+
+public class LogFormDto {
+
+    private String targetApi;
+    private String targetMethod;
+    private Long transactionTime;
+    private Long queryCounts;
+    private Long queryTime;
+
+    public static LogFormDto from(PerformanceLoggingForm logForm) {
+        final LogFormDto logFormDto = new LogFormDto();
+        logFormDto.targetApi = logForm.getTargetApi();
+        logFormDto.targetMethod = logForm.getTargetMethod();
+        logFormDto.transactionTime = logForm.getTransactionTime();
+        logFormDto.queryCounts = logForm.getQueryCounts();
+        logFormDto.queryTime = logForm.getQueryTime();
+        return logFormDto;
+    }
+
+    public String getTargetApi() {
+        return targetApi;
+    }
+
+    public String getTargetMethod() {
+        return targetMethod;
+    }
+
+    public Long getTransactionTime() {
+        return transactionTime;
+    }
+
+    public Long getQueryCounts() {
+        return queryCounts;
+    }
+
+    public Long getQueryTime() {
+        return queryTime;
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/PerformanceConfig.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceConfig.java
@@ -1,0 +1,20 @@
+package com.jujeol.performance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class PerformanceConfig implements WebMvcConfigurer {
+
+    private final PerformanceLoggingForm logForm;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new PerformanceInterceptor(logForm, objectMapper));
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/PerformanceInterceptor.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceInterceptor.java
@@ -23,7 +23,7 @@ public class PerformanceInterceptor implements HandlerInterceptor {
         if (request.getMethod().equals("OPTIONS")) {
             return true;
         }
-        logForm.setTransactionTime(System.currentTimeMillis());
+        logForm.setRequestTime(System.currentTimeMillis());
         return true;
     }
 
@@ -33,8 +33,8 @@ public class PerformanceInterceptor implements HandlerInterceptor {
         if (request.getMethod().equals("OPTIONS") || logForm.getTargetApi() == null || logForm.getTargetApi().isEmpty()) {
             return;
         }
-        final long transactionTime = System.currentTimeMillis() - logForm.getTransactionTime();
-        logForm.setTransactionTime(transactionTime);
+        final long transactionTime = System.currentTimeMillis() - logForm.getRequestTime();
+        logForm.setRequestTime(transactionTime);
 
         log.info(objectMapper.writeValueAsString(LogFormDto.from(logForm)));
     }

--- a/backend/src/main/java/com/jujeol/performance/PerformanceInterceptor.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceInterceptor.java
@@ -1,0 +1,41 @@
+package com.jujeol.performance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@RequiredArgsConstructor
+public class PerformanceInterceptor implements HandlerInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger("PERFORMANCE");
+
+    private final PerformanceLoggingForm logForm;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+            Object handler) throws Exception {
+        if (request.getMethod().equals("OPTIONS")) {
+            return true;
+        }
+        logForm.setTransactionTime(System.currentTimeMillis());
+        return true;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+            ModelAndView modelAndView) throws Exception {
+        if (request.getMethod().equals("OPTIONS") || logForm.getTargetApi() == null || logForm.getTargetApi().isEmpty()) {
+            return;
+        }
+        final long transactionTime = System.currentTimeMillis() - logForm.getTransactionTime();
+        logForm.setTransactionTime(transactionTime);
+
+        log.info(objectMapper.writeValueAsString(LogFormDto.from(logForm)));
+    }
+}

--- a/backend/src/main/java/com/jujeol/performance/PerformanceInterceptor.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceInterceptor.java
@@ -23,7 +23,7 @@ public class PerformanceInterceptor implements HandlerInterceptor {
         if (request.getMethod().equals("OPTIONS")) {
             return true;
         }
-        logForm.setRequestTime(System.currentTimeMillis());
+        logForm.setRequestTimeMils(System.currentTimeMillis());
         return true;
     }
 
@@ -33,8 +33,8 @@ public class PerformanceInterceptor implements HandlerInterceptor {
         if (request.getMethod().equals("OPTIONS") || logForm.getTargetApi() == null || logForm.getTargetApi().isEmpty()) {
             return;
         }
-        final long transactionTime = System.currentTimeMillis() - logForm.getRequestTime();
-        logForm.setRequestTime(transactionTime);
+        final long transactionTime = System.currentTimeMillis() - logForm.getRequestTimeMils();
+        logForm.setRequestTimeMils(transactionTime);
 
         log.info(objectMapper.writeValueAsString(LogFormDto.from(logForm)));
     }

--- a/backend/src/main/java/com/jujeol/performance/PerformanceLogger.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceLogger.java
@@ -21,7 +21,9 @@ public class PerformanceLogger {
     @Before("@within(org.springframework.web.bind.annotation.RestController) || @annotation(org.springframework.web.bind.annotation.RestController)")
     public void beforeController(JoinPoint joinPoint) {
         try {
-            final String test = logForm.toString();
+            // requestScope 인 logForm 의 toString()을 호출함으로써 제대로 할당이 되었는지 체크한다.
+            // (request 가 아닐 경우 ScopeNotActiveException 이 발생)
+            logForm.toString();
             final RequestApi requestApi = requestApiExtractor.extractRequestApi(joinPoint);
 
             logForm.setTargetApi(requestApi.getUrlForm());
@@ -36,7 +38,9 @@ public class PerformanceLogger {
         final Object proceed = proceedingJoinPoint.proceed();
 
         try {
-            final String test = logForm.toString();
+            // requestScope 인 logForm 의 toString()을 호출함으로써 제대로 할당이 되었는지 체크한다.
+            // (request 가 아닐 경우 ScopeNotActiveException 이 발생)
+            logForm.toString();
             return Proxy.newProxyInstance(
                     proceed.getClass().getClassLoader(),
                     proceed.getClass().getInterfaces(),

--- a/backend/src/main/java/com/jujeol/performance/PerformanceLogger.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceLogger.java
@@ -1,7 +1,5 @@
 package com.jujeol.performance;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Proxy;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
@@ -9,72 +7,42 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.support.ScopeNotActiveException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @Aspect
 @RequiredArgsConstructor
 public class PerformanceLogger {
 
-    private static final Logger log = LoggerFactory.getLogger("PERFORMANCE");
-
-    private final ObjectMapper objectMapper;
     private final RequestApiExtractor requestApiExtractor;
-
-    private ThreadLocal<PerformanceLoggingForm> logForm;
-
-    @Before("@within(org.springframework.transaction.annotation.Transactional) || @annotation(org.springframework.transaction.annotation.Transactional)")
-    public void beforeTransaction() {
-        final long startTransactionTime = System.currentTimeMillis();
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-
-            @Override
-            public void afterCompletion(int status) {
-                if(getLoggingForm().getTargetApi() == null || getLoggingForm().getTargetApi().isEmpty()) {
-                    return;
-                }
-                try {
-                    getLoggingForm()
-                        .setTransactionTime(System.currentTimeMillis() - startTransactionTime);
-                    log.info(objectMapper.writeValueAsString(getLoggingForm()));
-                } catch (JsonProcessingException ignored) {
-                } finally {
-                    logForm.remove();
-                }
-            }
-        });
-    }
+    private final PerformanceLoggingForm logForm;
 
     @Before("@within(org.springframework.web.bind.annotation.RestController) || @annotation(org.springframework.web.bind.annotation.RestController)")
     public void beforeController(JoinPoint joinPoint) {
-        final RequestApi requestApi = requestApiExtractor.extractRequestApi(joinPoint);
+        try {
+            final String test = logForm.toString();
+            final RequestApi requestApi = requestApiExtractor.extractRequestApi(joinPoint);
 
-        getLoggingForm().setTargetApi(requestApi.getUrlForm());
-        getLoggingForm().setTargetMethod(requestApi.getMethod());
+            logForm.setTargetApi(requestApi.getUrlForm());
+            logForm.setTargetMethod(requestApi.getMethod());
+        } catch (ScopeNotActiveException ignored) {
+        }
     }
 
 
     @Around("execution(* javax.sql.DataSource.getConnection())")
     public Object datasource(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         final Object proceed = proceedingJoinPoint.proceed();
-        return Proxy.newProxyInstance(
-            proceed.getClass().getClassLoader(),
-            proceed.getClass().getInterfaces(),
-            new ProxyConnectionHandler(proceed, getLoggingForm()));
-    }
 
-    private PerformanceLoggingForm getLoggingForm() {
-        if (logForm == null) {
-            logForm = new ThreadLocal<>();
+        try {
+            final String test = logForm.toString();
+            return Proxy.newProxyInstance(
+                    proceed.getClass().getClassLoader(),
+                    proceed.getClass().getInterfaces(),
+                    new ProxyConnectionHandler(proceed, logForm));
+        } catch (ScopeNotActiveException e) {
+            return proceed;
         }
-
-        if (logForm.get() == null) {
-            logForm.set(new PerformanceLoggingForm());
-        }
-        return logForm.get();
     }
 }

--- a/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
@@ -13,15 +13,15 @@ public class PerformanceLoggingForm {
 
     private String targetApi;
     private String targetMethod;
-    private Long requestTime;
+    private Long requestTimeMils;
     private Long queryCounts = 0L;
-    private Long queryTime = 0L;
+    private Long queryTimeMils = 0L;
 
     public void queryCountUp() {
         queryCounts++;
     }
 
     public void addQueryTime(Long queryTime) {
-        this.queryTime += queryTime;
+        this.queryTimeMils += queryTime;
     }
 }

--- a/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
@@ -2,9 +2,13 @@ package com.jujeol.performance;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 
 @Setter
 @Getter
+@Component
+@RequestScope
 public class PerformanceLoggingForm {
 
     private String targetApi;

--- a/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
+++ b/backend/src/main/java/com/jujeol/performance/PerformanceLoggingForm.java
@@ -13,7 +13,7 @@ public class PerformanceLoggingForm {
 
     private String targetApi;
     private String targetMethod;
-    private Long transactionTime;
+    private Long requestTime;
     private Long queryCounts = 0L;
     private Long queryTime = 0L;
 

--- a/backend/src/main/java/com/jujeol/review/domain/Review.java
+++ b/backend/src/main/java/com/jujeol/review/domain/Review.java
@@ -28,11 +28,11 @@ public class Review extends BaseEntity {
     @Embedded
     private ReviewContent content;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "drink_id")
     private Drink drink;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/backend/src/test/java/com/jujeol/testtool/response/MockMvcResult.java
+++ b/backend/src/test/java/com/jujeol/testtool/response/MockMvcResult.java
@@ -41,7 +41,20 @@ public class MockMvcResult implements HttpResponse {
     public <T> List<T> convertBodyToList(Class<T> tClass) {
         try {
             final String json = resultActions.andReturn().getResponse().getContentAsString();
-            return objectMapper.readValue(json, objectMapper.getTypeFactory().constructCollectionType(List.class, tClass));
+            final JsonNode jsonNode = objectMapper.readTree(json);
+
+            final List<T> list = new ArrayList<>();
+            final Iterator<JsonNode> data = jsonNode.withArray("data").elements();
+
+            data.forEachRemaining(dataNode -> {
+                try {
+                    final T hello = objectMapper.treeToValue(dataNode, tClass);
+                    list.add(hello);
+                } catch (JsonProcessingException e) {
+                    e.printStackTrace();
+                }
+            });
+            return list;
         } catch (UnsupportedEncodingException | JsonProcessingException e) {
             e.printStackTrace();
             return new ArrayList<>();

--- a/backend/src/test/java/com/jujeol/testtool/response/MockMvcResult.java
+++ b/backend/src/test/java/com/jujeol/testtool/response/MockMvcResult.java
@@ -41,20 +41,7 @@ public class MockMvcResult implements HttpResponse {
     public <T> List<T> convertBodyToList(Class<T> tClass) {
         try {
             final String json = resultActions.andReturn().getResponse().getContentAsString();
-            final JsonNode jsonNode = objectMapper.readTree(json);
-
-            final List<T> list = new ArrayList<>();
-            final Iterator<JsonNode> data = jsonNode.withArray("data").elements();
-
-            data.forEachRemaining(dataNode -> {
-                try {
-                    final T hello = objectMapper.treeToValue(dataNode, tClass);
-                    list.add(hello);
-                } catch (JsonProcessingException e) {
-                    e.printStackTrace();
-                }
-            });
-            return list;
+            return objectMapper.readValue(json, objectMapper.getTypeFactory().constructCollectionType(List.class, tClass));
         } catch (UnsupportedEncodingException | JsonProcessingException e) {
             e.printStackTrace();
             return new ArrayList<>();


### PR DESCRIPTION
## resolve #594 

### 설명
트랜잭션 전파 과정이 생기게 되면 기존 퍼포먼스 측정에서는 올바른 시간을 측정하기 어렵습니다.
그렇기에 트랜잭션 시간을 측정하는 것이 아니라 요청, 응답시간을 측정하는 것으로 변경하였습니다.

기존 ThreadLocal 로 관리하던 객체를 없애고 스프링 빈에서 Request Scope 로 설정해 관리하도록 변경했습니다.
여기서 Request 가 아닌 DataLoader 에서 이 객체에 접근하게 된다면 null 이 뜰 것이라고 예상했지만 null 이 아닌 프록시 형식으로 존재했기에 if(object == null) 이라는 확인이 먹히지 않았습니다.
해결 방안은 .toString() 을 선언한 뒤 ScopeNotActiveException 이 발생하는 지로 if(object == null) 처럼 이용했습니다.