### PR TITLE
feat: log4j 취약점 버전 이슈 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 
     // log
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
 
     // sonarqube
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.5.2'


### PR DESCRIPTION
## resolve #621 

### 설명
- logj4에서 문제되는 버전인 2.14버전을 2.15.0버전으로 올림.
- org/apache/logging/log4j/core/lookup/JndiLookup.class 가 포함되어있는 core 라이브러리를 업그레이드 하고, 그에 맞춰 기사용되고 있던 api 라이브러리도 버전 업그레이드. 

### 기타
참고 레퍼런스 - https://logging.apache.org/log4j/2.x/security.html