### PR TITLE
fix: 프론트엔드 빌드 오류 수정

### DIFF
--- a/.github/workflows/front-prod-deploy.yml
+++ b/.github/workflows/front-prod-deploy.yml
@@ -51,6 +51,5 @@ jobs:
           key: ${{ secrets.PROD_RSA_PRIVATE_KEY }}
           script:
             rm -rf /home/ubuntu/jujeol-jujeol/frontend/deploy/* &&
-            mkdir -p /home/ubuntu/jujeol-jujeol/frontend/deploy &&
             cp -r /home/ubuntu/jujeol-jujeol/frontend/frontend/build/* /home/ubuntu/jujeol-jujeol/frontend/deploy
           

--- a/.github/workflows/front-prod-deploy.yml
+++ b/.github/workflows/front-prod-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           host: ${{ secrets.PROD_HOST }}
           key: ${{ secrets.PROD_RSA_PRIVATE_KEY }}
           script:
-            rm -rf /home/ubuntu/jujeol-jujeol/frontend/deploy &&
+            rm -rf /home/ubuntu/jujeol-jujeol/frontend/deploy/* &&
             mkdir -p /home/ubuntu/jujeol-jujeol/frontend/deploy &&
             cp -r /home/ubuntu/jujeol-jujeol/frontend/frontend/build/* /home/ubuntu/jujeol-jujeol/frontend/deploy
           

--- a/.github/workflows/front-prod-deploy.yml
+++ b/.github/workflows/front-prod-deploy.yml
@@ -40,7 +40,17 @@ jobs:
           host: ${{ secrets.PROD_HOST }}
           key: ${{ secrets.PROD_RSA_PRIVATE_KEY }}
           script:
-            tar -xvf /home/ubuntu/jujeol-jujeol/frontend/frontend/deploy.tar &&
-            rm -rf /home/ubuntu/jujeol-jujeol/frontend/deploy/* &&
+            rm -rf /home/ubuntu/jujeol-jujeol/frontend/frontend/build &&
+            tar -xvf /home/ubuntu/jujeol-jujeol/frontend/frontend/deploy.tar -C /home/ubuntu/jujeol-jujeol/frontend/frontend
+            
+      - name: Change build files
+        uses: appleboy/ssh-action@master
+        with:
+          username: ubuntu
+          host: ${{ secrets.PROD_HOST }}
+          key: ${{ secrets.PROD_RSA_PRIVATE_KEY }}
+          script:
+            rm -rf /home/ubuntu/jujeol-jujeol/frontend/deploy &&
+            mkdir -p /home/ubuntu/jujeol-jujeol/frontend/deploy &&
             cp -r /home/ubuntu/jujeol-jujeol/frontend/frontend/build/* /home/ubuntu/jujeol-jujeol/frontend/deploy
           


### PR DESCRIPTION
## resolve #630 

### 설명
- 문제 원인은 `tar -xvf` 명령어에서 타겟 폴더를 입력하지 않았기 때문인 것으로 보입니다.
- 타겟 폴더가 설정되어 있지 않아 원하는 위치에 압축해제가 되지 않기 때문에 옮길 빌드 파일을 찾지 못하는 문제를 해결했습니다.
- 압축해제와 파일 삭제 및 옮기는 절차를 분리했습니다.