### PR TITLE
refactor: Jpql 사용하는 메서드를 querydsl로 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'org.sonarqube' version '3.3'
     id 'java'
     id 'jacoco'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 ext {
@@ -74,7 +75,32 @@ dependencies {
     // monitoring tools
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    //querydsl
+    implementation 'com.querydsl:querydsl-jpa'
 }
+
+//querydsl 추가 시작
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+configurations {
+    //아래를 지정하지 않으면, compile 로 걸린 JPA 의존성에 접근하지 못한다.
+    querydsl.extendsFrom compileClasspath
+}
+//querydsl 추가 끝
 
 processResources.dependsOn('copySecret')
 

--- a/backend/src/main/java/com/jujeol/DataLoader.java
+++ b/backend/src/main/java/com/jujeol/DataLoader.java
@@ -14,7 +14,7 @@ import com.jujeol.member.member.domain.Member;
 import com.jujeol.member.member.domain.nickname.Nickname;
 import com.jujeol.member.member.domain.repository.MemberRepository;
 import com.jujeol.preference.application.PreferenceService;
-import com.jujeol.preference.domain.PreferenceRepository;
+import com.jujeol.preference.domain.repository.PreferenceRepository;
 import com.jujeol.review.domain.repository.ReviewRepository;
 import java.util.Arrays;
 import java.util.List;

--- a/backend/src/main/java/com/jujeol/commons/config/QuerydslConfig.java
+++ b/backend/src/main/java/com/jujeol/commons/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.jujeol.commons.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/src/main/java/com/jujeol/drink/drink/domain/repository/DrinkCustomRepository.java
+++ b/backend/src/main/java/com/jujeol/drink/drink/domain/repository/DrinkCustomRepository.java
@@ -1,0 +1,31 @@
+package com.jujeol.drink.drink.domain.repository;
+
+import com.jujeol.drink.drink.domain.Drink;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DrinkCustomRepository {
+
+    Optional<Drink> findByIdWithFetch(Long drinkId);
+
+    Optional<Drink> findByName(String drinkName);
+
+    List<Drink> findDrinks(Pageable pageable);
+
+    List<Drink> findDrinksForMember(Long memberId, Pageable pageable, String category);
+
+    List<Drink> findDrinksForMember(Long memberId, Pageable pageable);
+
+    Page<Drink> findAllByCategorySorted(String category, Pageable pageable);
+
+    Page<Drink> findAllByCategory(String category, Pageable pageable);
+
+    Page<Drink> findAllSortByPreference(Pageable pageable);
+
+    List<Drink> findByKeyword(String keyword);
+
+    List<Drink> findByCategory(String searchWord);
+}

--- a/backend/src/main/java/com/jujeol/drink/drink/domain/repository/DrinkRepository.java
+++ b/backend/src/main/java/com/jujeol/drink/drink/domain/repository/DrinkRepository.java
@@ -1,49 +1,7 @@
 package com.jujeol.drink.drink.domain.repository;
 
 import com.jujeol.drink.drink.domain.Drink;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-public interface DrinkRepository extends JpaRepository<Drink, Long> {
-
-    @Query("select d from Drink d join fetch d.category where d.id = :drinkId")
-    Optional<Drink> findByIdWithFetch(Long drinkId);
-
-    @Query("select d from Drink d where d.name.name = :drinkName")
-    Optional<Drink> findByName(String drinkName);
-
-    @Query(value = "select d from Drink d join fetch d.category order by d.preferenceAvg desc")
-    List<Drink> findDrinks(Pageable pageable);
-
-    @Query("select d from Drink d join fetch d.category "
-            + "where (d.id in (select p.drink.id from Preference p where p.member.id = :memberId and p.rate > 3) "
-            + "or d.id not in (select p.drink.id from Preference p where p.member.id = :memberId)) and d.category.key = :category order by d.preferenceAvg desc")
-    List<Drink> findDrinksForMember(Long memberId, Pageable pageable, String category);
-
-    @Query("select d from Drink d join fetch d.category "
-            + "where d.id in (select p.drink.id from Preference p where p.member.id = :memberId and p.rate > 3) "
-            + "or d.id not in (select p.drink.id from Preference p where p.member.id = :memberId) order by d.preferenceAvg desc")
-    List<Drink> findDrinksForMember(Long memberId, Pageable pageable);
-
-    @Query(value = "select d from Drink d join fetch d.category c where c.key = :category order by d.preferenceAvg desc"
-            ,countQuery = "select count(d) from Drink d where d.category.key = :category")
-    Page<Drink> findAllByCategorySorted(String category, Pageable pageable);
-
-    @Query(value = "select d from Drink d join fetch d.category c where c.key = :category"
-            ,countQuery = "select count(d) from Drink d where d.category.key = :category")
-    Page<Drink> findAllByCategory(String category, Pageable pageable);
-
-    @Query(value = "select d from Drink d join fetch d.category order by d.preferenceAvg desc",
-    countQuery = "select count(d) from Drink d")
-    Page<Drink> findAllSortByPreference(Pageable pageable);
-
-    @Query(value = "select d from Drink d join fetch d.category where d.name.name like %:keyword% or d.englishName.englishName like %:keyword%")
-    List<Drink> findByKeyword(String keyword);
-
-    @Query(value = "select d from Drink d join fetch d.category c where c.name = :searchWord")
-    List<Drink> findByCategory(String searchWord);
+public interface DrinkRepository extends JpaRepository<Drink, Long>, DrinkCustomRepository {
 }

--- a/backend/src/main/java/com/jujeol/drink/drink/domain/repository/DrinkRepositoryImpl.java
+++ b/backend/src/main/java/com/jujeol/drink/drink/domain/repository/DrinkRepositoryImpl.java
@@ -1,0 +1,155 @@
+package com.jujeol.drink.drink.domain.repository;
+
+import com.jujeol.drink.drink.domain.Drink;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.jujeol.drink.category.domain.QCategory.category;
+import static com.jujeol.drink.drink.domain.QDrink.drink;
+import static com.jujeol.preference.domain.QPreference.preference;
+
+@RequiredArgsConstructor
+public class DrinkRepositoryImpl implements DrinkCustomRepository {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public Optional<Drink> findByIdWithFetch(Long drinkId) {
+        return Optional.ofNullable(
+                factory.selectFrom(drink)
+                        .join(drink.category, category)
+                        .fetchJoin()
+                        .where(drink.id.eq(drinkId))
+                        .fetchOne());
+    }
+
+    @Override
+    public Optional<Drink> findByName(String drinkName) {
+        return Optional.ofNullable(
+                factory.selectFrom(drink)
+                        .where(drink.name.name.eq(drinkName))
+                        .fetchOne());
+    }
+
+    @Override
+    public List<Drink> findDrinks(Pageable pageable) {
+        return factory.selectFrom(drink)
+                .join(drink.category, category)
+                .fetchJoin()
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(drink.preferenceAvg.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<Drink> findDrinksForMember(Long memberId, Pageable pageable) {
+        return factory.selectFrom(drink)
+                .join(drink.category, category)
+                .fetchJoin()
+                .where((isMemberAndGtThanRate(memberId)
+                        .or(isNotMember(memberId))))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(drink.preferenceAvg.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<Drink> findDrinksForMember(Long memberId, Pageable pageable, String categoryKey) {
+        return factory.selectFrom(drink)
+                .join(drink.category, category)
+                .fetchJoin()
+                .where((isMemberAndGtThanRate(memberId)
+                        .or(isNotMember(memberId)))
+                        .and(drink.category.key.eq(categoryKey)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(drink.preferenceAvg.desc())
+                .fetch();
+    }
+
+    private BooleanExpression isMemberAndGtThanRate(Long memberId) {
+        return drink.id.in(
+                JPAExpressions
+                        .select(preference.drink.id)
+                        .from(preference)
+                        .where(preference.member.id.eq(memberId)
+                                .and(preference.rate.gt(3))));
+    }
+
+    private BooleanExpression isNotMember(Long memberId) {
+        return drink.id.notIn(
+                JPAExpressions
+                        .select(preference.drink.id)
+                        .from(preference)
+                        .where(preference.member.id.eq(memberId))
+                        .orderBy(drink.preferenceAvg.desc()));
+    }
+
+    @Override
+    public Page<Drink> findAllByCategorySorted(String categoryKey, Pageable pageable) {
+        QueryResults<Drink> result = factory.selectFrom(drink)
+                .join(drink.category, category)
+                .fetchJoin()
+                .where(drink.category.key.eq(categoryKey))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(drink.preferenceAvg.desc())
+                .fetchResults();
+
+        return new PageImpl<>(result.getResults(), pageable, result.getTotal());
+    }
+
+    @Override
+    public Page<Drink> findAllByCategory(String categoryKey, Pageable pageable) {
+        QueryResults<Drink> result = factory.selectFrom(drink)
+                .join(drink.category, category)
+                .fetchJoin()
+                .where(drink.category.key.eq(categoryKey))
+                .fetchResults();
+
+        return new PageImpl<>(result.getResults(), pageable, result.getTotal());
+    }
+
+    @Override
+    public Page<Drink> findAllSortByPreference(Pageable pageable) {
+        QueryResults<Drink> result = factory.selectFrom(drink)
+                .join(drink.category, category)
+                .fetchJoin()
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(drink.preferenceAvg.desc())
+                .fetchResults();
+
+        return new PageImpl<>(result.getResults(), pageable, result.getTotal());
+    }
+
+    @Override
+    public List<Drink> findByKeyword(String keyword) {
+        return factory.selectFrom(drink)
+                .join(drink.category, category)
+                .fetchJoin()
+                .where(drink.name.name.like("%" + keyword + "%")
+                        .or(drink.englishName.englishName.like("%" + keyword + "%")))
+                .fetch();
+    }
+
+    @Override
+    public List<Drink> findByCategory(String searchWord) {
+        return factory.selectFrom(drink)
+                .join(drink.category, category)
+                .fetchJoin()
+                .where(drink.category.name.eq(searchWord))
+                .fetch();
+    }
+}

--- a/backend/src/main/java/com/jujeol/drink/recommend/application/RecommendFactory.java
+++ b/backend/src/main/java/com/jujeol/drink/recommend/application/RecommendFactory.java
@@ -5,7 +5,7 @@ import com.jujeol.drink.recommend.domain.RecommendForAnonymous;
 import com.jujeol.drink.recommend.domain.RecommendForMember;
 import com.jujeol.drink.recommend.infrastructure.slope.Recommender;
 import com.jujeol.member.auth.ui.LoginMember;
-import com.jujeol.preference.domain.PreferenceRepository;
+import com.jujeol.preference.domain.repository.PreferenceRepository;
 import java.util.EnumMap;
 import java.util.Map;
 import org.springframework.stereotype.Component;

--- a/backend/src/main/java/com/jujeol/drink/recommend/domain/RecommendForMember.java
+++ b/backend/src/main/java/com/jujeol/drink/recommend/domain/RecommendForMember.java
@@ -10,11 +10,10 @@ import com.jujeol.drink.recommend.infrastructure.slope.DataModel;
 import com.jujeol.drink.recommend.infrastructure.slope.RecommendationResponse;
 import com.jujeol.drink.recommend.infrastructure.slope.Recommender;
 import com.jujeol.preference.domain.Preference;
-import com.jujeol.preference.domain.PreferenceRepository;
+import com.jujeol.preference.domain.repository.PreferenceRepository;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 

--- a/backend/src/main/java/com/jujeol/member/member/application/MemberService.java
+++ b/backend/src/main/java/com/jujeol/member/member/application/MemberService.java
@@ -40,7 +40,7 @@ public class MemberService {
                 .orElseThrow(NoSuchMemberException::new);
 
         final Optional<Member> memberByNickname = memberRepository
-                .findByNickname(memberDto.getNickname());
+                .findByNicknameNickname(memberDto.getNickname());
 
         if (duplicatedName(memberDto, member, memberByNickname)) {
             throw new DuplicateMemberException();

--- a/backend/src/main/java/com/jujeol/member/member/domain/repository/MemberCustomRepository.java
+++ b/backend/src/main/java/com/jujeol/member/member/domain/repository/MemberCustomRepository.java
@@ -1,0 +1,14 @@
+package com.jujeol.member.member.domain.repository;
+
+import com.jujeol.member.member.domain.Member;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberCustomRepository {
+
+    Optional<Member> findByProvideId(String provideId);
+
+    List<Member> findOneStartingWithNicknameAndMostRecent(String nickname, Pageable pageable);
+}

--- a/backend/src/main/java/com/jujeol/member/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/com/jujeol/member/member/domain/repository/MemberRepository.java
@@ -7,16 +7,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
-
-    @Query("select m from Member m where m.provider.provideId = :provideId")
-    Optional<Member> findByProvideId(String provideId);
-
-    @Query("select m from Member m where m.nickname.nickname like :nickname% order by m.createdAt desc")
-    List<Member> findOneStartingWithNicknameAndMostRecent(String nickname, Pageable pageable);
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
 
     boolean existsByNicknameNickname(String nickname);
 
-    @Query("select m from Member m where m.nickname.nickname = :nickname")
-    Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByNicknameNickname(String nickname);
 }

--- a/backend/src/main/java/com/jujeol/member/member/domain/repository/MemberRepositoryImpl.java
+++ b/backend/src/main/java/com/jujeol/member/member/domain/repository/MemberRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.jujeol.member.member.domain.repository;
+
+import com.jujeol.member.member.domain.Member;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.jujeol.member.member.domain.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberCustomRepository {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public Optional<Member> findByProvideId(String provideId) {
+        return Optional.ofNullable(factory.selectFrom(member)
+                .where(member.provider.provideId.eq(provideId))
+                .fetchOne());
+    }
+
+    @Override
+    public List<Member> findOneStartingWithNicknameAndMostRecent(String nickname, Pageable pageable) {
+        return factory.selectFrom(member)
+                .where(member.nickname.nickname.like(nickname + "%"))
+                .orderBy(member.createdAt.desc())
+                .fetch();
+    }
+}

--- a/backend/src/main/java/com/jujeol/member/member/domain/repository/MemberRepositoryImpl.java
+++ b/backend/src/main/java/com/jujeol/member/member/domain/repository/MemberRepositoryImpl.java
@@ -17,9 +17,10 @@ public class MemberRepositoryImpl implements MemberCustomRepository {
 
     @Override
     public Optional<Member> findByProvideId(String provideId) {
-        return Optional.ofNullable(factory.selectFrom(member)
-                .where(member.provider.provideId.eq(provideId))
-                .fetchOne());
+        return Optional.ofNullable(
+                factory.selectFrom(member)
+                        .where(member.provider.provideId.eq(provideId))
+                        .fetchOne());
     }
 
     @Override

--- a/backend/src/main/java/com/jujeol/preference/application/PreferenceService.java
+++ b/backend/src/main/java/com/jujeol/preference/application/PreferenceService.java
@@ -5,7 +5,7 @@ import com.jujeol.drink.drink.domain.repository.DrinkRepository;
 import com.jujeol.drink.drink.exception.NotFoundDrinkException;
 import com.jujeol.member.member.application.dto.PreferenceDto;
 import com.jujeol.preference.domain.Preference;
-import com.jujeol.preference.domain.PreferenceRepository;
+import com.jujeol.preference.domain.repository.PreferenceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceCustomRepository.java
+++ b/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceCustomRepository.java
@@ -1,0 +1,17 @@
+package com.jujeol.preference.domain.repository;
+
+import com.jujeol.preference.domain.Preference;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PreferenceCustomRepository {
+
+    Optional<Double> averageOfPreferenceRate(Long drinkId);
+
+    Page<Preference> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
+    List<Preference> findAllByCategory(String category);
+}

--- a/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepository.java
+++ b/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepository.java
@@ -1,31 +1,17 @@
 package com.jujeol.preference.domain.repository;
 
-import java.util.List;
-import java.util.Optional;
-
 import com.jujeol.preference.domain.Preference;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
-public interface PreferenceRepository extends JpaRepository<Preference, Long> {
+import java.util.Optional;
+
+public interface PreferenceRepository extends JpaRepository<Preference, Long>, PreferenceCustomRepository {
 
     Optional<Preference> findByMemberIdAndDrinkId(Long memberId, Long drinkId);
 
     @Modifying
     void deleteByMemberIdAndDrinkId(Long memberId, Long drinkId);
-
-    @Query("SELECT AVG(p.rate) FROM Preference p WHERE p.drink.id = :drinkId")
-    Optional<Double> averageOfPreferenceRate(Long drinkId);
-
-    @Query(value = "Select p From Preference p join fetch p.drink d join fetch p.member join fetch d.category where p.member.id = :memberId order by p.createdAt desc",
-            countQuery = "Select count(p) From Preference p where p.member.id = :memberId")
-    Page<Preference> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
-
-    @Query("select p from Preference p where p.drink.category.name = :category")
-    List<Preference> findAllByCategory(String category);
 
     @Modifying
     void deleteByDrinkId(Long drinkId);

--- a/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepository.java
+++ b/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepository.java
@@ -1,7 +1,9 @@
-package com.jujeol.preference.domain;
+package com.jujeol.preference.domain.repository;
 
 import java.util.List;
 import java.util.Optional;
+
+import com.jujeol.preference.domain.Preference;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,7 +11,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PreferenceRepository extends JpaRepository<Preference, Long> {
-
 
     Optional<Preference> findByMemberIdAndDrinkId(Long memberId, Long drinkId);
 

--- a/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepositoryImpl.java
+++ b/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepositoryImpl.java
@@ -40,6 +40,8 @@ public class PreferenceRepositoryImpl implements PreferenceCustomRepository {
                 .join(preference.member, member)
                 .fetchJoin()
                 .where(preference.member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .orderBy(preference.createdAt.desc())
                 .fetchResults();
 

--- a/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepositoryImpl.java
+++ b/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.jujeol.preference.domain.repository;
+
+import com.jujeol.preference.domain.Preference;
+import com.querydsl.core.QueryResults;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.jujeol.drink.category.domain.QCategory.category;
+import static com.jujeol.drink.drink.domain.QDrink.drink;
+import static com.jujeol.member.member.domain.QMember.member;
+import static com.jujeol.preference.domain.QPreference.preference;
+
+@RequiredArgsConstructor
+public class PreferenceRepositoryImpl implements PreferenceCustomRepository {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public Optional<Double> averageOfPreferenceRate(Long drinkId) {
+        return Optional.ofNullable(
+                factory.select(preference.rate.avg())
+                        .from(preference)
+                        .where(preference.drink.id.eq(drinkId))
+                        .fetchOne());
+    }
+
+    @Override
+    public Page<Preference> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable) {
+        QueryResults<Preference> result = factory.selectFrom(preference)
+                .join(preference.drink, drink)
+                .fetchJoin()
+                .join(drink.category, category)
+                .fetchJoin()
+                .join(preference.member, member)
+                .fetchJoin()
+                .where(preference.member.id.eq(memberId))
+                .orderBy(preference.createdAt.desc())
+                .fetchResults();
+
+        return new PageImpl<>(result.getResults(), pageable, result.getTotal());
+    }
+
+    @Override
+    public List<Preference> findAllByCategory(String category) {
+        return factory.selectFrom(preference)
+                .where(preference.drink.category.name.eq(category))
+                .fetch();
+    }
+}

--- a/backend/src/main/java/com/jujeol/review/application/ReviewService.java
+++ b/backend/src/main/java/com/jujeol/review/application/ReviewService.java
@@ -8,7 +8,7 @@ import com.jujeol.member.member.domain.Member;
 import com.jujeol.member.member.domain.repository.MemberRepository;
 import com.jujeol.member.member.exception.NoSuchMemberException;
 import com.jujeol.preference.domain.Preference;
-import com.jujeol.preference.domain.PreferenceRepository;
+import com.jujeol.preference.domain.repository.PreferenceRepository;
 import com.jujeol.review.application.dto.MemberSimpleDto;
 import com.jujeol.review.application.dto.ReviewCreateDto;
 import com.jujeol.review.application.dto.ReviewWithAuthorDto;

--- a/backend/src/main/java/com/jujeol/review/domain/repository/ReviewCustomRepository.java
+++ b/backend/src/main/java/com/jujeol/review/domain/repository/ReviewCustomRepository.java
@@ -1,0 +1,16 @@
+package com.jujeol.review.domain.repository;
+
+import com.jujeol.review.domain.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ReviewCustomRepository {
+
+    Page<Review> findAllByDrinkId(Long drinkId, Pageable pageable);
+
+    List<Review> findByDrinkIdAndMemberId(Long drinkId, Long memberId, Pageable pageable);
+
+    Page<Review> findReviewsOfMine(Long memberId, Pageable pageable);
+}

--- a/backend/src/main/java/com/jujeol/review/domain/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/jujeol/review/domain/repository/ReviewRepository.java
@@ -1,22 +1,7 @@
 package com.jujeol.review.domain.repository;
 
 import com.jujeol.review.domain.Review;
-import java.util.List;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
-
-    @Query(value = "select r from Review r join fetch r.member where r.drink.id = :drinkId",
-            countQuery = "select count(r) from Review r where r.drink.id = :drinkId")
-    Page<Review> findAllByDrinkId(Long drinkId, Pageable pageable);
-
-    @Query("select r from Review r where r.drink.id = :drinkId and r.member.id = :memberId order by r.createdAt desc")
-    List<Review> findByDrinkIdAndMemberId(Long drinkId, Long memberId, Pageable pageable);
-
-    @Query(value = "select r from Review r join fetch r.drink d join fetch d.category where r.member.id = :memberId order by r.createdAt desc",
-            countQuery = "select count(r) from Review r where r.member.id = :memberId")
-    Page<Review> findReviewsOfMine(Long memberId, Pageable pageable);
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewCustomRepository {
 }

--- a/backend/src/main/java/com/jujeol/review/domain/repository/ReviewRepositoryImpl.java
+++ b/backend/src/main/java/com/jujeol/review/domain/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.jujeol.review.domain.repository;
+
+import com.jujeol.review.domain.Review;
+import com.querydsl.core.QueryResults;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.jujeol.drink.category.domain.QCategory.category;
+import static com.jujeol.drink.drink.domain.QDrink.drink;
+import static com.jujeol.member.member.domain.QMember.member;
+import static com.jujeol.review.domain.QReview.review;
+
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewCustomRepository {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public Page<Review> findAllByDrinkId(Long drinkId, Pageable pageable) {
+        QueryResults<Review> result = factory.selectFrom(review)
+                .join(review.member, member)
+                .fetchJoin()
+                .where(review.drink.id.eq(drinkId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchResults();
+
+        return new PageImpl<>(result.getResults(), pageable, result.getTotal());
+    }
+
+    @Override
+    public List<Review> findByDrinkIdAndMemberId(Long drinkId, Long memberId, Pageable pageable) {
+        return factory.selectFrom(review)
+                .where(review.drink.id.eq(drinkId).and(review.member.id.eq(memberId)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(review.createdAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public Page<Review> findReviewsOfMine(Long memberId, Pageable pageable) {
+        QueryResults<Review> result = factory.selectFrom(review)
+                .join(review.drink, drink)
+                .fetchJoin()
+                .join(drink.category, category)
+                .fetchJoin()
+                .where(review.member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(review.createdAt.desc())
+                .fetchResults();
+
+        return new PageImpl<>(result.getResults(), pageable, result.getTotal());
+    }
+}

--- a/backend/src/test/java/com/jujeol/member/domain/MemberInfoRepositoryTest.java
+++ b/backend/src/test/java/com/jujeol/member/domain/MemberInfoRepositoryTest.java
@@ -2,6 +2,7 @@ package com.jujeol.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jujeol.commons.config.QuerydslConfig;
 import com.jujeol.drink.category.domain.Category;
 import com.jujeol.drink.category.domain.CategoryRepository;
 import com.jujeol.drink.drink.domain.Drink;
@@ -27,11 +28,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
+@Import(value = QuerydslConfig.class)
 @DataJpaTest
 public class MemberInfoRepositoryTest {
 

--- a/backend/src/test/java/com/jujeol/member/domain/MemberInfoRepositoryTest.java
+++ b/backend/src/test/java/com/jujeol/member/domain/MemberInfoRepositoryTest.java
@@ -15,7 +15,7 @@ import com.jujeol.member.member.domain.Member;
 import com.jujeol.member.member.domain.nickname.Nickname;
 import com.jujeol.member.member.domain.repository.MemberRepository;
 import com.jujeol.preference.domain.Preference;
-import com.jujeol.preference.domain.PreferenceRepository;
+import com.jujeol.preference.domain.repository.PreferenceRepository;
 import com.jujeol.review.domain.Review;
 import com.jujeol.review.domain.repository.ReviewRepository;
 import java.util.Collections;

--- a/backend/src/test/java/com/jujeol/member/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/jujeol/member/domain/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package com.jujeol.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jujeol.commons.config.QuerydslConfig;
 import com.jujeol.member.auth.domain.Provider;
 import com.jujeol.member.auth.domain.ProviderName;
 import com.jujeol.member.member.domain.Biography;
@@ -13,10 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
+@Import(value = QuerydslConfig.class)
 @DataJpaTest
 public class MemberRepositoryTest {
 

--- a/backend/src/test/java/com/jujeol/member/domain/PreferenceRepositoryTest.java
+++ b/backend/src/test/java/com/jujeol/member/domain/PreferenceRepositoryTest.java
@@ -2,6 +2,7 @@ package com.jujeol.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jujeol.commons.config.QuerydslConfig;
 import com.jujeol.drink.category.domain.Category;
 import com.jujeol.drink.category.domain.CategoryRepository;
 import com.jujeol.drink.drink.domain.Drink;
@@ -19,9 +20,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
+@Import(value = QuerydslConfig.class)
 @DataJpaTest
 public class PreferenceRepositoryTest {
 

--- a/backend/src/test/java/com/jujeol/member/domain/PreferenceRepositoryTest.java
+++ b/backend/src/test/java/com/jujeol/member/domain/PreferenceRepositoryTest.java
@@ -13,7 +13,7 @@ import com.jujeol.member.auth.domain.ProviderName;
 import com.jujeol.member.member.domain.Member;
 import com.jujeol.member.member.domain.repository.MemberRepository;
 import com.jujeol.preference.domain.Preference;
-import com.jujeol.preference.domain.PreferenceRepository;
+import com.jujeol.preference.domain.repository.PreferenceRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/jujeol/review/domain/repository/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/jujeol/review/domain/repository/ReviewRepositoryTest.java
@@ -2,6 +2,7 @@ package com.jujeol.review.domain.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jujeol.commons.config.QuerydslConfig;
 import com.jujeol.drink.category.domain.Category;
 import com.jujeol.drink.category.domain.CategoryRepository;
 import com.jujeol.drink.drink.domain.Drink;
@@ -25,11 +26,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
+@Import(value = QuerydslConfig.class)
 @DataJpaTest
 public class ReviewRepositoryTest {
 


### PR DESCRIPTION
## resolve #633

### 설명
- Jpql 사용하지 않는 쿼리 메서드는 기존 JpaRepository에 위치하고 CustomRepository를 통해 querydsl 구현
- @DataJpaTest에 querydsl 적용을 위해 @Import(QuerydslConfig.class) 추가
