### PR TITLE
refactor: 주류에 맞는 회원 평점을 가져오는 방식을 in 쿼리로 변경

### DIFF
--- a/backend/src/main/java/com/jujeol/preference/application/PreferenceService.java
+++ b/backend/src/main/java/com/jujeol/preference/application/PreferenceService.java
@@ -12,6 +12,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 public class PreferenceService {
@@ -74,5 +78,14 @@ public class PreferenceService {
 
     public void deletePreferenceByDrinkId(Long id) {
         preferenceRepository.deleteByDrinkId(id);
+    }
+
+    public Map<Long, Preference> findWithDrinkIds(List<Long> drinkIds, Long memberId) {
+        Map<Long, Preference> result = new HashMap<>();
+        List<Preference> preferences = preferenceRepository.findByMemberWithDrinkIds(drinkIds, memberId);
+        for (Preference preference : preferences) {
+            result.put(preference.getDrink().getId(), preference);
+        }
+        return result;
     }
 }

--- a/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepository.java
+++ b/backend/src/main/java/com/jujeol/preference/domain/repository/PreferenceRepository.java
@@ -3,7 +3,9 @@ package com.jujeol.preference.domain.repository;
 import com.jujeol.preference.domain.Preference;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PreferenceRepository extends JpaRepository<Preference, Long>, PreferenceCustomRepository {
@@ -15,4 +17,7 @@ public interface PreferenceRepository extends JpaRepository<Preference, Long>, P
 
     @Modifying
     void deleteByDrinkId(Long drinkId);
+
+    @Query("select p from Preference p where p.member.id = :memberId and p.drink.id in :drinkIds")
+    List<Preference> findByMemberWithDrinkIds(List<Long> drinkIds, Long memberId);
 }


### PR DESCRIPTION
## resolve #638 

### 설명
각 주류에 대한 멤버가 남긴 평점을 찾아올 때 n+1 쿼리가 나가는 문제가 존재했습니다. (추천 주류 뿐만이 아니라 모든 주류가 이런 방식으로 가져오게 되었습니다)

이 부분을 in 쿼리로 변경했습니다.